### PR TITLE
AART-809: respond 500 in error scenarios

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.immregistries</groupId>
 	<artifactId>smm-tester</artifactId>
 	<packaging>war</packaging>
-	<version>2.29.0</version>
+	<version>2.30.0</version>
 	<name>IIS HL7 Tester and Simple Message Mover</name>
 	<description></description>
 	<!-- TODO <organization> <name>company name</name> <url>company url</url> 

--- a/src/main/java/org/immregistries/smm/cdc/CDCWSDLServer.java
+++ b/src/main/java/org/immregistries/smm/cdc/CDCWSDLServer.java
@@ -42,19 +42,24 @@ public abstract class CDCWSDLServer {
     } catch (MessageTooLargeFault mtlf) {
       out = quitelyResetBuffer(resp, out);
       processor.doPrintException(out, mtlf);
+      resp.sendError(500);
     } catch (SecurityFault sf) {
       out = quitelyResetBuffer(resp, out);
       processor.doPrintException(out, sf);
+      resp.sendError(500);
     } catch (UnsupportedOperationFault uof) {
       out = quitelyResetBuffer(resp, out);
       processor.doPrintException(out, uof);
+      resp.sendError(500);
     } catch (UnknownFault uf) {
       out = quitelyResetBuffer(resp, out);
       processor.doPrintException(out, uf);
+      resp.sendError(500);
     } catch (Exception e) {
       UnknownFault uf = new UnknownFault("Exception ocurred", e);
       out = quitelyResetBuffer(resp, out);
       processor.doPrintException(out, uf);
+      resp.sendError(500);
     } finally {
       out.close();
     }


### PR DESCRIPTION
IIS Sandbox delegates building the http response to smm-tester, so in order to resolve return 500s in exception scenarios, smm-tester needs to update.