### PR TITLE
AART-1769 updates CDATA parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.immregistries</groupId>
 	<artifactId>smm-tester</artifactId>
-	<version>2.31.2</version>
+	<version>2.31.3</version>
 	<packaging>war</packaging>
 
   <name>IIS HL7 Tester and Simple Message Mover</name>
@@ -107,15 +107,23 @@
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-local</artifactId>
             <version>1.8.0</version>
-			<scope>test</scope>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-http</artifactId>
             <version>1.8.0</version>
-			<scope>test</scope>
+            <scope>test</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+
 
 		<!-- JUNIT DEPENDENCY FOR TESTING -->
 		<dependency>

--- a/src/main/java/org/immregistries/smm/tester/connectors/fl/SubmitSingleMessageResponse.java
+++ b/src/main/java/org/immregistries/smm/tester/connectors/fl/SubmitSingleMessageResponse.java
@@ -8,6 +8,7 @@
 
 
 package org.immregistries.smm.tester.connectors.fl;
+import org.apache.commons.lang3.StringUtils;
 
 
 /**
@@ -415,6 +416,9 @@ public class SubmitSingleMessageResponse implements org.apache.axis2.databinding
 
 
             java.lang.String content = reader.getElementText();
+            if(StringUtils.isEmpty(content)){
+                content = reader.getText();
+            }
 
             object.set_return(
                 org.apache.axis2.databinding.utils.ConverterUtil.convertToString(content));

--- a/src/main/java/org/immregistries/smm/tester/connectors/tlep/SubmitSingleMessageResponseType.java
+++ b/src/main/java/org/immregistries/smm/tester/connectors/tlep/SubmitSingleMessageResponseType.java
@@ -6,7 +6,7 @@
  */
 
 package org.immregistries.smm.tester.connectors.tlep;
-
+import org.apache.commons.lang3.StringUtils;
 /**
  * SubmitSingleMessageResponseType bean class
  */
@@ -371,6 +371,9 @@ public class SubmitSingleMessageResponseType implements org.apache.axis2.databin
               reader.getAttributeValue("http://www.w3.org/2001/XMLSchema-instance", "nil");
           if (!"true".equals(nillableValue) && !"1".equals(nillableValue)) {
             java.lang.String content = reader.getElementText();
+            if(StringUtils.isEmpty(content)){
+                content = reader.getText();
+            }
             object.set_return(
                 org.apache.axis2.databinding.utils.ConverterUtil.convertToString(content));
           } else {


### PR DESCRIPTION
In situations where the CDATA element is present in the "return" tag,
the old version of axis, along with updates to javax result in a quiet
return of empty string from the auto generated code in this repo