### PR TITLE
AART-1871: Allow SoapConnector to accept SSLContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.immregistries</groupId>
 	<artifactId>smm-tester</artifactId>
-	<version>2.31.3</version>
+	<version>2.32.0</version>
 	<packaging>war</packaging>
 
   <name>IIS HL7 Tester and Simple Message Mover</name>
@@ -170,6 +170,13 @@
 		    <artifactId>json</artifactId>
 		    <version>20211205</version>
 		</dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.4</version>
+        </dependency>
 
 	</dependencies>
 	<build>

--- a/src/main/java/org/immregistries/smm/tester/connectors/ConnectorFactory.java
+++ b/src/main/java/org/immregistries/smm/tester/connectors/ConnectorFactory.java
@@ -1,4 +1,5 @@
 package org.immregistries.smm.tester.connectors;
+import javax.net.ssl.SSLContext;
 
 public class ConnectorFactory {
 
@@ -40,9 +41,13 @@ public class ConnectorFactory {
       {TYPE_IZ_GATEWAY, "IZ Gateway"}};
 
   public static Connector getConnector(String type, String label, String url) throws Exception {
+      return getConnector(type, label, url, null);
+  }
+
+  public static Connector getConnector(String type, String label, String url, SSLContext sslContext) throws Exception {
     Connector connector = null;
     if (type.equals(TYPE_SOAP)) {
-      connector = new SoapConnector(label, url);
+      connector = new SoapConnector(label, url, sslContext);
     } else if (type.equals(TYPE_MLLP)) {
       connector = new MLLPConnector(label, url);
     } else if (type.equals(TYPE_NM_SOAP)) {

--- a/src/main/java/org/immregistries/smm/tester/connectors/SoapConnector.java
+++ b/src/main/java/org/immregistries/smm/tester/connectors/SoapConnector.java
@@ -24,8 +24,11 @@ public class SoapConnector extends HttpConnector {
   private Client_Service clientService = null;
 
   public SoapConnector(String label, String url) throws Exception {
+      this(label, url, null);
+  }
+  public SoapConnector(String label, String url, javax.net.ssl.SSLContext sslContext) throws Exception {
     super(label, url, ConnectorFactory.TYPE_SOAP);
-    clientService = new Client_ServiceStub(this.url);
+    clientService = new Client_ServiceStub(this.url, sslContext);
   }
   
   @Override

--- a/src/main/java/org/immregistries/smm/tester/connectors/tlep/Client_ServiceStub.java
+++ b/src/main/java/org/immregistries/smm/tester/connectors/tlep/Client_ServiceStub.java
@@ -5,6 +5,7 @@
  * (05:33:49 IST)
  */
 package org.immregistries.smm.tester.connectors.tlep;
+import java.security.cert.CertificateException;
 
 /*
  * Client_ServiceStub java implementation
@@ -142,11 +143,16 @@ public class Client_ServiceStub extends org.apache.axis2.client.Stub implements 
     this(configurationContext, targetEndpoint, false);
   }
 
+  public Client_ServiceStub(org.apache.axis2.context.ConfigurationContext configurationContext,
+      java.lang.String targetEndpoint, boolean useSeparateListener)
+      throws org.apache.axis2.AxisFault {
+    this(configurationContext, targetEndpoint, useSeparateListener, null);
+    }
   /**
    * Constructor that takes in a configContext and useseperate listner
    */
   public Client_ServiceStub(org.apache.axis2.context.ConfigurationContext configurationContext,
-      java.lang.String targetEndpoint, boolean useSeparateListener)
+      java.lang.String targetEndpoint, boolean useSeparateListener, javax.net.ssl.SSLContext sslContext)
       throws org.apache.axis2.AxisFault {
     // To populate AxisService
     populateAxisService();
@@ -165,6 +171,22 @@ public class Client_ServiceStub extends org.apache.axis2.client.Stub implements 
         .setSoapVersionURI(org.apache.axiom.soap.SOAP12Constants.SOAP_ENVELOPE_NAMESPACE_URI);
 
     _serviceClient.getOptions().setTimeOutInMilliSeconds(2 * 60 * 1000);
+
+    if(sslContext != null){
+      //set SSLContext for SOAP calls
+      try {
+        org.apache.http.conn.ssl.SSLSocketFactory sf = new org.apache.http.conn.ssl.SSLSocketFactory(sslContext);
+        org.apache.http.conn.scheme.Scheme httpsScheme = new org.apache.http.conn.scheme.Scheme("https", 443, sf);
+        org.apache.http.conn.scheme.SchemeRegistry schemeRegistry = new org.apache.http.conn.scheme.SchemeRegistry();
+        schemeRegistry.register(httpsScheme);
+        org.apache.http.conn.ClientConnectionManager cm =  new org.apache.http.impl.conn.SingleClientConnManager(schemeRegistry);
+        org.apache.http.client.HttpClient httpClient = new org.apache.http.impl.client.DefaultHttpClient(cm);
+
+        _serviceClient.getOptions().setProperty(org.apache.axis2.transport.http.HTTPConstants.CACHED_HTTP_CLIENT, httpClient);
+      }catch(Exception e){
+        //womp womp, couldn't set the offered context
+      }
+    }
 
   }
 
@@ -194,6 +216,9 @@ public class Client_ServiceStub extends org.apache.axis2.client.Stub implements 
     this(null, targetEndpoint);
   }
 
+  public Client_ServiceStub(java.lang.String targetEndpoint, javax.net.ssl.SSLContext sslContext) throws org.apache.axis2.AxisFault {
+    this(null, targetEndpoint, false, sslContext);
+  }
 
   /**
    * Auto generated method signature submit single message


### PR DESCRIPTION
The SoapConnection code in this project inherits the default java SSL
Context, and assumes it will be able to connect.  In the case of AART
using this as a library, it was not able to pass down its magic context
changes, and some endpoints would fail to connect.