### PR TITLE
Support for concatenating in a transformer with +=

### DIFF
--- a/src/main/java/org/immregistries/smm/transform/Transform.java
+++ b/src/main/java/org/immregistries/smm/transform/Transform.java
@@ -25,6 +25,7 @@ public class Transform {
   protected boolean all = false;
   protected String testCaseId = null;
   protected Transform valueTransform = null;
+  protected boolean concatenate = false;
 
   public boolean isSegmentRepeatSet() {
     return segmentRepeatSet;
@@ -152,5 +153,13 @@ public class Transform {
 
   public void setValueTransform(Transform valueTransform) {
     this.valueTransform = valueTransform;
+  }
+  
+  public boolean isConcatenate() {
+    return concatenate;
+  }
+  
+  public void setConcatenate(boolean concatenate) {
+    this.concatenate = concatenate;
   }
 }

--- a/src/main/java/org/immregistries/smm/transform/Transformer.java
+++ b/src/main/java/org/immregistries/smm/transform/Transformer.java
@@ -2084,7 +2084,10 @@ public class Transformer {
                     endPos = endPosAmper;
                   }
                 }
-                String lineNew = lineResult.substring(0, pos);
+                
+                // if we're concatenating ("PID-5.1+=MORE" for example
+                // we want to include the existing 5.1 text in the substring
+                String lineNew = lineResult.substring(0, t.concatenate ? endPos : pos);
 
                 if (newValue.toUpperCase().startsWith("[MAP ")) {
                   String oldValue = lineResult.substring(pos, endPos);
@@ -2463,6 +2466,14 @@ public class Transformer {
 
   public static Transform readHL7Reference(String line, int endOfInput) {
     Transform t = null;
+    
+    int posPlusEquals = line.indexOf("+=");
+    boolean concatenate = false;
+    if (posPlusEquals != -1 && posPlusEquals + 1 == endOfInput) {
+      endOfInput--;
+      concatenate = true;
+    }
+    
     String testCaseId = null;
     {
       int posColons = line.indexOf("::");
@@ -2502,6 +2513,7 @@ public class Transformer {
       t = new Transform();
       t.testCaseId = testCaseId;
       t.all = all;
+      t.concatenate = concatenate;
       if (posDash == -1 || posDash >= endOfInput) {
         posDash = endOfInput;
       }

--- a/src/test/java/org/immregistries/smm/transform/TransformerTest.java
+++ b/src/test/java/org/immregistries/smm/transform/TransformerTest.java
@@ -444,4 +444,106 @@ public class TransformerTest extends TestCase
   {
     testTransform("run procedure ADD_FUNDING_ELGIBILITY_TO_ALL_RXA\n", TP_01_START, TP_01_FINAL);
   }
+  
+  @Test
+  public void testDoSetField() {
+    testTransform("PID-5.1=Greg", TEST1_ORIGINAL, CONCATENATE_FINAL_1);
+    testTransform("PID-5.1+=Greg", TEST1_ORIGINAL, CONCATENATE_FINAL_2);
+    
+    testTransform("PID-5.1=[PID-5.2]", TEST1_ORIGINAL, CONCATENATE_FINAL_3);
+    testTransform("PID-5.1+=[PID-5.2]", TEST1_ORIGINAL, CONCATENATE_FINAL_4);
+    
+    testTransform("PID-11.5=[PID-13.7]", TEST1_ORIGINAL, CONCATENATE_FINAL_5);
+    testTransform("PID-11.5+=[PID-13.7]", TEST1_ORIGINAL, CONCATENATE_FINAL_6);
+  }
+  
+  private static final String CONCATENATE_FINAL_1 = "MSH|^~\\&|||||20150303154321-0500||VXU^V04^VXU_V04|G98P76.1245|P|2.5.1|\r"
+      + "PID|1||G98P76^^^OIS-TEST^MR||Greg^Callis^G^^^^L|Copeland^Lona|20020222|M|||374 Refugio Ln^^Woodland Park^MI^49309^USA^P||^PRN^PH^^^231^5679656|\r"
+      + "NK1|1|Copeland^Lona|MTH^Mother^HL70063|\r"
+      + "PV1|1|R|\r"
+      + "ORC|RE||G98P76.1^OIS|\r"
+      + "RXA|0|1|20110220||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.2^OIS|\r"
+      + "RXA|0|1|20130224||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.3^OIS|||||||I-23432^Burden^Donna^A^^^^^NIST-AA-1||57422^RADON^NICHOLAS^^^^^^NIST-AA-1^L|\r"
+      + "RXA|0|1|20150303||83^Hep A^CVX|0.5|mL^milliliters^UCUM||00^Administered^NIP001||||||G2789NM||MSD^Merck and Co^MVX||||A|\r"
+      + "OBX|1|CE|64994-7^Vaccine funding program eligibility category^LN|1|V02^VFC eligible - Medicaid/Medicaid Managed Care^HL70064||||||F|||20150303|||VXC40^Eligibility captured at the immunization level^CDCPHINVS|\r"
+      + "OBX|2|CE|30956-7^Vaccine Type^LN|2|85^Hepatitis A^CVX||||||F|\r"
+      + "OBX|3|TS|29768-9^Date vaccine information statement published^LN|2|20111025||||||F|\r"
+      + "OBX|4|TS|29769-7^Date vaccine information statement presented^LN|2|20150303||||||F|\r";
+  
+  private static final String CONCATENATE_FINAL_2 = "MSH|^~\\&|||||20150303154321-0500||VXU^V04^VXU_V04|G98P76.1245|P|2.5.1|\r"
+      + "PID|1||G98P76^^^OIS-TEST^MR||BurtGreg^Callis^G^^^^L|Copeland^Lona|20020222|M|||374 Refugio Ln^^Woodland Park^MI^49309^USA^P||^PRN^PH^^^231^5679656|\r"
+      + "NK1|1|Copeland^Lona|MTH^Mother^HL70063|\r"
+      + "PV1|1|R|\r"
+      + "ORC|RE||G98P76.1^OIS|\r"
+      + "RXA|0|1|20110220||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.2^OIS|\r"
+      + "RXA|0|1|20130224||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.3^OIS|||||||I-23432^Burden^Donna^A^^^^^NIST-AA-1||57422^RADON^NICHOLAS^^^^^^NIST-AA-1^L|\r"
+      + "RXA|0|1|20150303||83^Hep A^CVX|0.5|mL^milliliters^UCUM||00^Administered^NIP001||||||G2789NM||MSD^Merck and Co^MVX||||A|\r"
+      + "OBX|1|CE|64994-7^Vaccine funding program eligibility category^LN|1|V02^VFC eligible - Medicaid/Medicaid Managed Care^HL70064||||||F|||20150303|||VXC40^Eligibility captured at the immunization level^CDCPHINVS|\r"
+      + "OBX|2|CE|30956-7^Vaccine Type^LN|2|85^Hepatitis A^CVX||||||F|\r"
+      + "OBX|3|TS|29768-9^Date vaccine information statement published^LN|2|20111025||||||F|\r"
+      + "OBX|4|TS|29769-7^Date vaccine information statement presented^LN|2|20150303||||||F|\r";
+  
+  private static final String CONCATENATE_FINAL_3 = "MSH|^~\\&|||||20150303154321-0500||VXU^V04^VXU_V04|G98P76.1245|P|2.5.1|\r"
+      + "PID|1||G98P76^^^OIS-TEST^MR||Callis^Callis^G^^^^L|Copeland^Lona|20020222|M|||374 Refugio Ln^^Woodland Park^MI^49309^USA^P||^PRN^PH^^^231^5679656|\r"
+      + "NK1|1|Copeland^Lona|MTH^Mother^HL70063|\r"
+      + "PV1|1|R|\r"
+      + "ORC|RE||G98P76.1^OIS|\r"
+      + "RXA|0|1|20110220||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.2^OIS|\r"
+      + "RXA|0|1|20130224||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.3^OIS|||||||I-23432^Burden^Donna^A^^^^^NIST-AA-1||57422^RADON^NICHOLAS^^^^^^NIST-AA-1^L|\r"
+      + "RXA|0|1|20150303||83^Hep A^CVX|0.5|mL^milliliters^UCUM||00^Administered^NIP001||||||G2789NM||MSD^Merck and Co^MVX||||A|\r"
+      + "OBX|1|CE|64994-7^Vaccine funding program eligibility category^LN|1|V02^VFC eligible - Medicaid/Medicaid Managed Care^HL70064||||||F|||20150303|||VXC40^Eligibility captured at the immunization level^CDCPHINVS|\r"
+      + "OBX|2|CE|30956-7^Vaccine Type^LN|2|85^Hepatitis A^CVX||||||F|\r"
+      + "OBX|3|TS|29768-9^Date vaccine information statement published^LN|2|20111025||||||F|\r"
+      + "OBX|4|TS|29769-7^Date vaccine information statement presented^LN|2|20150303||||||F|\r";
+  
+  private static final String CONCATENATE_FINAL_4 = "MSH|^~\\&|||||20150303154321-0500||VXU^V04^VXU_V04|G98P76.1245|P|2.5.1|\r"
+      + "PID|1||G98P76^^^OIS-TEST^MR||BurtCallis^Callis^G^^^^L|Copeland^Lona|20020222|M|||374 Refugio Ln^^Woodland Park^MI^49309^USA^P||^PRN^PH^^^231^5679656|\r"
+      + "NK1|1|Copeland^Lona|MTH^Mother^HL70063|\r"
+      + "PV1|1|R|\r"
+      + "ORC|RE||G98P76.1^OIS|\r"
+      + "RXA|0|1|20110220||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.2^OIS|\r"
+      + "RXA|0|1|20130224||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.3^OIS|||||||I-23432^Burden^Donna^A^^^^^NIST-AA-1||57422^RADON^NICHOLAS^^^^^^NIST-AA-1^L|\r"
+      + "RXA|0|1|20150303||83^Hep A^CVX|0.5|mL^milliliters^UCUM||00^Administered^NIP001||||||G2789NM||MSD^Merck and Co^MVX||||A|\r"
+      + "OBX|1|CE|64994-7^Vaccine funding program eligibility category^LN|1|V02^VFC eligible - Medicaid/Medicaid Managed Care^HL70064||||||F|||20150303|||VXC40^Eligibility captured at the immunization level^CDCPHINVS|\r"
+      + "OBX|2|CE|30956-7^Vaccine Type^LN|2|85^Hepatitis A^CVX||||||F|\r"
+      + "OBX|3|TS|29768-9^Date vaccine information statement published^LN|2|20111025||||||F|\r"
+      + "OBX|4|TS|29769-7^Date vaccine information statement presented^LN|2|20150303||||||F|\r";
+  
+  private static final String CONCATENATE_FINAL_5 = "MSH|^~\\&|||||20150303154321-0500||VXU^V04^VXU_V04|G98P76.1245|P|2.5.1|\r"
+      + "PID|1||G98P76^^^OIS-TEST^MR||Burt^Callis^G^^^^L|Copeland^Lona|20020222|M|||374 Refugio Ln^^Woodland Park^MI^5679656^USA^P||^PRN^PH^^^231^5679656|\r"
+      + "NK1|1|Copeland^Lona|MTH^Mother^HL70063|\r"
+      + "PV1|1|R|\r"
+      + "ORC|RE||G98P76.1^OIS|\r"
+      + "RXA|0|1|20110220||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.2^OIS|\r"
+      + "RXA|0|1|20130224||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.3^OIS|||||||I-23432^Burden^Donna^A^^^^^NIST-AA-1||57422^RADON^NICHOLAS^^^^^^NIST-AA-1^L|\r"
+      + "RXA|0|1|20150303||83^Hep A^CVX|0.5|mL^milliliters^UCUM||00^Administered^NIP001||||||G2789NM||MSD^Merck and Co^MVX||||A|\r"
+      + "OBX|1|CE|64994-7^Vaccine funding program eligibility category^LN|1|V02^VFC eligible - Medicaid/Medicaid Managed Care^HL70064||||||F|||20150303|||VXC40^Eligibility captured at the immunization level^CDCPHINVS|\r"
+      + "OBX|2|CE|30956-7^Vaccine Type^LN|2|85^Hepatitis A^CVX||||||F|\r"
+      + "OBX|3|TS|29768-9^Date vaccine information statement published^LN|2|20111025||||||F|\r"
+      + "OBX|4|TS|29769-7^Date vaccine information statement presented^LN|2|20150303||||||F|\r";
+  
+  private static final String CONCATENATE_FINAL_6 = "MSH|^~\\&|||||20150303154321-0500||VXU^V04^VXU_V04|G98P76.1245|P|2.5.1|\r"
+      + "PID|1||G98P76^^^OIS-TEST^MR||Burt^Callis^G^^^^L|Copeland^Lona|20020222|M|||374 Refugio Ln^^Woodland Park^MI^493095679656^USA^P||^PRN^PH^^^231^5679656|\r"
+      + "NK1|1|Copeland^Lona|MTH^Mother^HL70063|\r"
+      + "PV1|1|R|\r"
+      + "ORC|RE||G98P76.1^OIS|\r"
+      + "RXA|0|1|20110220||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.2^OIS|\r"
+      + "RXA|0|1|20130224||62^HPV^CVX|999|||01^Historical^NIP001||||||||||||A|\r"
+      + "ORC|RE||G98P76.3^OIS|||||||I-23432^Burden^Donna^A^^^^^NIST-AA-1||57422^RADON^NICHOLAS^^^^^^NIST-AA-1^L|\r"
+      + "RXA|0|1|20150303||83^Hep A^CVX|0.5|mL^milliliters^UCUM||00^Administered^NIP001||||||G2789NM||MSD^Merck and Co^MVX||||A|\r"
+      + "OBX|1|CE|64994-7^Vaccine funding program eligibility category^LN|1|V02^VFC eligible - Medicaid/Medicaid Managed Care^HL70064||||||F|||20150303|||VXC40^Eligibility captured at the immunization level^CDCPHINVS|\r"
+      + "OBX|2|CE|30956-7^Vaccine Type^LN|2|85^Hepatitis A^CVX||||||F|\r"
+      + "OBX|3|TS|29768-9^Date vaccine information statement published^LN|2|20111025||||||F|\r"
+      + "OBX|4|TS|29769-7^Date vaccine information statement presented^LN|2|20150303||||||F|\r";
 }


### PR DESCRIPTION
https://github.com/immregistries-internal/AART/issues/2326

Dev branch: AART-2326

I added support for concatenation in transformers with the += syntax.

So something like this is possible now:

`PID-5.1+=Greg` adds "Greg" to the end of the last name.
`PID-5.1+=[PID-5.2]` adds the text in the first name to the end of the last name.
`PID-11.5+=[PID-13.7]` adds the phone number to the end of the zip code.

For documentation, I would add this text to this wiki page:

https://github.com/immregistries/smm-tester/wiki/Transform-Logic

## Concatenation

Text can be appended to fields using the `+=` operator:

`PID-5.1+=Burke`

If the existing PID-5.1 field is set to `Caspar`, after the concatenation transformation it will be set to `CasparBurke`.

Other fields can also be referenced in a concatenation, such as:

`PID-5.1=[PID-5.2]`