### PR TITLE
AART-2499 - PopulateQueryFromUpdate supports repeat reference

### DIFF
--- a/src/main/java/org/immregistries/smm/transform/Transformer.java
+++ b/src/main/java/org/immregistries/smm/transform/Transformer.java
@@ -624,7 +624,7 @@ public class Transformer {
 
   public String transform(TestCaseMessage testCaseMessage, Connector connector) {
     String actualTestCase = testCaseMessage.getTestCaseNumber();
-    if (actualTestCase.equals("")) {
+    if ("".equals(actualTestCase)) {
       actualTestCase = REP_PAT_MRN;
     }
     String quickTransforms = convertQuickTransforms(testCaseMessage, actualTestCase);
@@ -2527,11 +2527,29 @@ public class Transformer {
 
     TestCaseMessage matchingMessage = null;
 
+    matchingMessage =
+        getRepeatReferenceTestCaseMessage(transformRequest, testCaseId, testCaseMessageMap);
+
+    if (matchingMessage == null) {
+      return null;
+    }
+
+    return new BufferedReader(new StringReader(matchingMessage.getMessageText()));
+  }
+
+  public static TestCaseMessage getRepeatReferenceTestCaseMessage(TransformRequest transformRequest,
+      String testCaseId, Map<String, TestCaseMessage> testCaseMessageMap) {
+
+    if (testCaseMessageMap == null) {
+      return null;
+    }
+
+    TestCaseMessage matchingMessage;
     // REPEAT_REF is the repeat set of characters
     // indicating we want to try and match up the current repeat number against the same number of the reference
     // so if test case ID is 1.1REPEAT_REF (right now 1.1-?), and the current test is 1.2-1, then we will try and match against 1.1-1
     if (testCaseId.endsWith(REPEAT_REF)) {
-      // drop the ~ for now, we know it's there
+      // drop the REPEAT_REF for now, we know it's there
       testCaseId = testCaseId.substring(0, testCaseId.length() - REPEAT_REF.length());
 
       if (transformRequest.getCurrentTestCaseMessage() == null) {
@@ -2540,6 +2558,7 @@ public class Transformer {
       } else {
         // we do know what the current test case is, see if it's ends in -1, -2, etc.
         String currentTestCaseId = transformRequest.getCurrentTestCaseMessage().getTestCaseNumber();
+
         if (currentTestCaseId.matches(".*-\\d+$")) {
           // the current test case ID ends in -1, -2, etc.
           int repeatIndex = currentTestCaseId.lastIndexOf("-");
@@ -2561,11 +2580,7 @@ public class Transformer {
       matchingMessage = testCaseMessageMap.get(testCaseId);
     }
 
-    if (matchingMessage == null) {
-      return null;
-    }
-
-    return new BufferedReader(new StringReader(matchingMessage.getMessageText()));
+    return matchingMessage;
   }
 
   public static Transform readHL7Reference(String ref) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/PopulateQueryFromUpdate.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/PopulateQueryFromUpdate.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.immregistries.smm.transform.TestCaseMessage;
 import org.immregistries.smm.transform.TransformRequest;
 import org.immregistries.smm.transform.Transformer;
@@ -46,13 +47,13 @@ public class PopulateQueryFromUpdate implements ProcedureInterface {
   public void doProcedure(TransformRequest transformRequest, LinkedList<String> tokenList)
       throws IOException {
     TestCaseMessage testCaseMessage = null;
-    if (tokenList.size() > 0) {
+    if (!tokenList.isEmpty()) {
       String token = tokenList.removeFirst();
-      if (token != null && !token.equals("")) {
+      if (StringUtils.isNotBlank(token)) {
         Map<String, TestCaseMessage> testCaseMessageMap = transformRequest.getTestCaseMessageMap();
-        if (testCaseMessageMap != null) {
-          testCaseMessage = testCaseMessageMap.get(token);
-        }
+
+        testCaseMessage = Transformer.getRepeatReferenceTestCaseMessage(transformRequest, token,
+            testCaseMessageMap);
       }
     }
     if (testCaseMessage != null) {

--- a/src/test/java/org/immregistries/smm/transform/procedure/PopulateQueryFromUpdateTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/PopulateQueryFromUpdateTest.java
@@ -5,52 +5,101 @@ import java.util.Map;
 import org.immregistries.smm.transform.TestCaseMessage;
 import org.immregistries.smm.transform.Transformer;
 import org.junit.Test;
-
 import junit.framework.TestCase;
 
 public class PopulateQueryFromUpdateTest extends TestCase {
-  
-  
 
-  private static final String UPDATE_MESSAGE = "MSH|^~\\&|||||20221117085729-0700||VXU^V04^VXU_V04|V43H49.2pl|P|2.5.1|||ER|AL|||||Z22^CDCPHINVS|\r" + 
-      "PID|1||V43H49^^^AIRA-TEST^MR||EsceibreAIRA^CharlotteAIRA^Mare^^^^L|PerryAIRA^KrisAIRA^^^^^M|20181123|F||2106-3^White^CDCREC|1345 Zulst St^^Saginaw^MI^48605^USA^P||^PRN^PH^^^989^5114370|||||||||2186-5^not Hispanic or Latino^CDCREC|\r" + 
-      "PD1|||||||||||02^Reminder/Recall - any method^HL70215|||||A|20221117|20221117|\r" + 
-      "NK1|1|EsceibreAIRA^KrisAIRA^^^^^L|MTH^Mother^HL70063|1345 Zulst St^^Saginaw^MI^48605^USA^P|^PRN^PH^^^989^5114370|\r" + 
-      "ORC|RE||V43H49.3^AIRA|||||||I-23432^Burden^Donna^A^^^^^NIST-AA-1^^^^PRN||57422^RADON^NICHOLAS^^^^^^NIST-AA-1^L^^^PRN|\r" + 
-      "RXA|0|1|20221117||03^MMR^CVX|0.5|mL^milliliters^UCUM||00^Administered^NIP001||||||U1747GW||MSD^Merck and Co^MVX|||CP|A|\r" + 
-      "RXR|C38299^^NCIT|LA^^HL70163|\r" + 
-      "OBX|1|CE|64994-7^Vaccine funding program eligibility category^LN|1|V02^VFC eligible - Medicaid/Medicaid Managed Care^HL70064||||||F|||20221117|||VXC40^Eligibility captured at the immunization level^CDCPHINVS|\r" + 
-      "OBX|2|CE|30956-7^Vaccine Type^LN|2|03^MMR^CVX||||||F|\r" + 
-      "OBX|3|TS|29768-9^Date vaccine information statement published^LN|2|20120420||||||F|\r" + 
-      "OBX|4|TS|29769-7^Date vaccine information statement presented^LN|2|20221117||||||F|\r";
+  private static final String UPDATE_MESSAGE =
+      "MSH|^~\\&|||||20221117085729-0700||VXU^V04^VXU_V04|V43H49.2pl|P|2.5.1|||ER|AL|||||Z22^CDCPHINVS|\r"
+          + "PID|1||V43H49^^^AIRA-TEST^MR||EsceibreAIRA^CharlotteAIRA^Mare^^^^L|PerryAIRA^KrisAIRA^^^^^M|20181123|F||2106-3^White^CDCREC|1345 Zulst St^^Saginaw^MI^48605^USA^P||^PRN^PH^^^989^5114370|||||||||2186-5^not Hispanic or Latino^CDCREC|\r"
+          + "PD1|||||||||||02^Reminder/Recall - any method^HL70215|||||A|20221117|20221117|\r"
+          + "NK1|1|EsceibreAIRA^KrisAIRA^^^^^L|MTH^Mother^HL70063|1345 Zulst St^^Saginaw^MI^48605^USA^P|^PRN^PH^^^989^5114370|\r"
+          + "ORC|RE||V43H49.3^AIRA|||||||I-23432^Burden^Donna^A^^^^^NIST-AA-1^^^^PRN||57422^RADON^NICHOLAS^^^^^^NIST-AA-1^L^^^PRN|\r"
+          + "RXA|0|1|20221117||03^MMR^CVX|0.5|mL^milliliters^UCUM||00^Administered^NIP001||||||U1747GW||MSD^Merck and Co^MVX|||CP|A|\r"
+          + "RXR|C38299^^NCIT|LA^^HL70163|\r"
+          + "OBX|1|CE|64994-7^Vaccine funding program eligibility category^LN|1|V02^VFC eligible - Medicaid/Medicaid Managed Care^HL70064||||||F|||20221117|||VXC40^Eligibility captured at the immunization level^CDCPHINVS|\r"
+          + "OBX|2|CE|30956-7^Vaccine Type^LN|2|03^MMR^CVX||||||F|\r"
+          + "OBX|3|TS|29768-9^Date vaccine information statement published^LN|2|20120420||||||F|\r"
+          + "OBX|4|TS|29769-7^Date vaccine information statement presented^LN|2|20221117||||||F|\r";
 
-  private static final String QUERY_MESSAGE_ORIGINAL = "MSH|^~\\&|||||20221117085830-0700||QBP^Q11^QBP_Q11|1668700713602.3|P|2.5.1|||ER|AL|||||Z44^CDCPHINVS|||\r" + 
-      "QPD|Z44^Request Evaluated History and Forecast^CDCPHINVS|1668700713602.3|M65D50^^^AIRA-TEST^MR|MonroeAIRA^ZadorAIRA^Hannu^^^^L|ClarkAIRA^AdaliaAIRA^^^^^M|20181124|M|1582 Tpe St^^Harrisville^MI^48740^USA^P|^PRN^PH^^^989^4668008|||||\r" + 
-      "RCP|I|1^RD&Records&HL70126\r";
+  private static final String UPDATE_MESSAGE_2 =
+      "MSH|^~\\&|||||20221117085729-0700||VXU^V04^VXU_V04|V43H49.2pl|P|2.5.1|||ER|AL|||||Z22^CDCPHINVS|\r"
+          + "PID|1||V43H49^^^AIRA-TEST^MR||HamiltonAIRA^AlexanderAIRA^Mare^^^^L|PerryAIRA^KrisAIRA^^^^^M|20181123|F||2106-3^White^CDCREC|1345 Zulst St^^Saginaw^MI^48605^USA^P||^PRN^PH^^^989^5114370|||||||||2186-5^not Hispanic or Latino^CDCREC|\r"
+          + "PD1|||||||||||02^Reminder/Recall - any method^HL70215|||||A|20221117|20221117|\r"
+          + "NK1|1|EsceibreAIRA^KrisAIRA^^^^^L|MTH^Mother^HL70063|1345 Zulst St^^Saginaw^MI^48605^USA^P|^PRN^PH^^^989^5114370|\r"
+          + "ORC|RE||V43H49.3^AIRA|||||||I-23432^Burden^Donna^A^^^^^NIST-AA-1^^^^PRN||57422^RADON^NICHOLAS^^^^^^NIST-AA-1^L^^^PRN|\r"
+          + "RXA|0|1|20221117||03^MMR^CVX|0.5|mL^milliliters^UCUM||00^Administered^NIP001||||||U1747GW||MSD^Merck and Co^MVX|||CP|A|\r"
+          + "RXR|C38299^^NCIT|LA^^HL70163|\r"
+          + "OBX|1|CE|64994-7^Vaccine funding program eligibility category^LN|1|V02^VFC eligible - Medicaid/Medicaid Managed Care^HL70064||||||F|||20221117|||VXC40^Eligibility captured at the immunization level^CDCPHINVS|\r"
+          + "OBX|2|CE|30956-7^Vaccine Type^LN|2|03^MMR^CVX||||||F|\r"
+          + "OBX|3|TS|29768-9^Date vaccine information statement published^LN|2|20120420||||||F|\r"
+          + "OBX|4|TS|29769-7^Date vaccine information statement presented^LN|2|20221117||||||F|\r";
 
-  private static final String QUERY_MESSAGE_FINAL = "MSH|^~\\&|||||20221117085830-0700||QBP^Q11^QBP_Q11|1668700713602.3|P|2.5.1|||ER|AL|||||Z44^CDCPHINVS|||\r" + 
-      "QPD|Z44^Request Evaluated History and Forecast^CDCPHINVS|1668700713602.3|V43H49^^^AIRA-TEST^MR|EsceibreAIRA^CharlotteAIRA^Mare^^^^L|PerryAIRA^KrisAIRA^^^^^M|20181123|F|1345 Zulst St^^Saginaw^MI^48605^USA^P|^PRN^PH^^^989^5114370|||||\r" + 
-      "RCP|I|1^RD&Records&HL70126\r";
+  private static final String QUERY_MESSAGE_ORIGINAL =
+      "MSH|^~\\&|||||20221117085830-0700||QBP^Q11^QBP_Q11|1668700713602.3|P|2.5.1|||ER|AL|||||Z44^CDCPHINVS|||\r"
+          + "QPD|Z44^Request Evaluated History and Forecast^CDCPHINVS|1668700713602.3|M65D50^^^AIRA-TEST^MR|MonroeAIRA^ZadorAIRA^Hannu^^^^L|ClarkAIRA^AdaliaAIRA^^^^^M|20181124|M|1582 Tpe St^^Harrisville^MI^48740^USA^P|^PRN^PH^^^989^4668008|||||\r"
+          + "RCP|I|1^RD&Records&HL70126\r";
+
+  private static final String QUERY_MESSAGE_FINAL =
+      "MSH|^~\\&|||||20221117085830-0700||QBP^Q11^QBP_Q11|1668700713602.3|P|2.5.1|||ER|AL|||||Z44^CDCPHINVS|||\r"
+          + "QPD|Z44^Request Evaluated History and Forecast^CDCPHINVS|1668700713602.3|V43H49^^^AIRA-TEST^MR|EsceibreAIRA^CharlotteAIRA^Mare^^^^L|PerryAIRA^KrisAIRA^^^^^M|20181123|F|1345 Zulst St^^Saginaw^MI^48605^USA^P|^PRN^PH^^^989^5114370|||||\r"
+          + "RCP|I|1^RD&Records&HL70126\r";
+
+  private static final String QUERY_MESSAGE_FINAL_2 =
+      "MSH|^~\\&|||||20221117085830-0700||QBP^Q11^QBP_Q11|1668700713602.3|P|2.5.1|||ER|AL|||||Z44^CDCPHINVS|||\r"
+          + "QPD|Z44^Request Evaluated History and Forecast^CDCPHINVS|1668700713602.3|V43H49^^^AIRA-TEST^MR|HamiltonAIRA^AlexanderAIRA^Mare^^^^L|PerryAIRA^KrisAIRA^^^^^M|20181123|F|1345 Zulst St^^Saginaw^MI^48605^USA^P|^PRN^PH^^^989^5114370|||||\r"
+          + "RCP|I|1^RD&Records&HL70126\r";
 
 
   @Test
   public void test() {
-    test(UPDATE_MESSAGE, QUERY_MESSAGE_ORIGINAL,  QUERY_MESSAGE_FINAL);
-  }
-
-  public void test(String update, String queryOriginal, String queryFinal) {
     TestCaseMessage testCaseMessage = new TestCaseMessage();
-    testCaseMessage.setOriginalMessage(queryOriginal);
+    testCaseMessage.setOriginalMessage(QUERY_MESSAGE_ORIGINAL);
     testCaseMessage.appendCustomTransformation(" run procedure POPULATE_QUERY_FROM_UPDATE query");
-    {
-      Map<String, TestCaseMessage> testCaseMessageMap = new HashMap<String, TestCaseMessage>();
-      TestCaseMessage tcm = new TestCaseMessage();
-      tcm.setMessageText(update);
-      testCaseMessageMap.put("query", tcm);
-      testCaseMessage.registerTestCaseMap(testCaseMessageMap);
-    }
+
+    Map<String, TestCaseMessage> testCaseMessageMap = new HashMap<String, TestCaseMessage>();
+    TestCaseMessage tcm = new TestCaseMessage();
+    tcm.setMessageText(UPDATE_MESSAGE);
+    testCaseMessageMap.put("query", tcm);
+    testCaseMessage.registerTestCaseMap(testCaseMessageMap);
+
     Transformer transformer = new Transformer();
     transformer.transform(testCaseMessage);
-    assertEquals(queryFinal, testCaseMessage.getMessageText());
+    assertEquals(QUERY_MESSAGE_FINAL, testCaseMessage.getMessageText());
+  }
+
+  @Test
+  public void test_repeats() {
+    TestCaseMessage testCaseMessage = new TestCaseMessage();
+    testCaseMessage.setOriginalMessage(QUERY_MESSAGE_ORIGINAL);
+    testCaseMessage.appendCustomTransformation(" run procedure POPULATE_QUERY_FROM_UPDATE query-?");
+    testCaseMessage.setTestCaseNumber("case");
+
+    Map<String, TestCaseMessage> testCaseMessageMap = new HashMap<String, TestCaseMessage>();
+    TestCaseMessage tcm = new TestCaseMessage();
+    tcm.setMessageText(UPDATE_MESSAGE);
+    testCaseMessageMap.put("query", tcm);
+    testCaseMessage.registerTestCaseMap(testCaseMessageMap);
+
+    Transformer transformer = new Transformer();
+    transformer.transform(testCaseMessage);
+    assertEquals(QUERY_MESSAGE_FINAL, testCaseMessage.getMessageText());
+
+    testCaseMessage.setTestCaseNumber("case-1");
+    transformer = new Transformer();
+    transformer.transform(testCaseMessage);
+    assertEquals(QUERY_MESSAGE_FINAL, testCaseMessage.getMessageText());
+
+    TestCaseMessage tcm2 = new TestCaseMessage();
+    tcm2.setMessageText(UPDATE_MESSAGE_2);
+    testCaseMessageMap.put("query-1", tcm2);
+    transformer = new Transformer();
+    transformer.transform(testCaseMessage);
+    assertEquals(QUERY_MESSAGE_FINAL_2, testCaseMessage.getMessageText());
+
+    testCaseMessage.setTestCaseNumber("case-2");
+    transformer = new Transformer();
+    transformer.transform(testCaseMessage);
+    assertEquals(QUERY_MESSAGE_FINAL, testCaseMessage.getMessageText());
   }
 }


### PR DESCRIPTION
Extracted `getRepeatReferenceTestCaseMessage()` into its own static method, which can be called from anywhere to get the repeat referenced test case from anywhere, including now `PopulateQueryFromUpdate`.