### PR TITLE
AART-2666 - Common method to make emails valid after procedures

### DIFF
--- a/src/main/java/org/immregistries/smm/transform/procedure/AbstractTypoProcedure.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/AbstractTypoProcedure.java
@@ -36,7 +36,7 @@ public abstract class AbstractTypoProcedure extends ProcedureCommon implements P
     this.transformer = transformer;
   }
 
-  private Field field;
+  protected Field field;
 
   protected AbstractTypoProcedure(Field field) {
     this.field = field;

--- a/src/main/java/org/immregistries/smm/transform/procedure/AddVariation.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/AddVariation.java
@@ -44,7 +44,7 @@ public class AddVariation extends ProcedureCommon implements ProcedureInterface 
       if ("PID".equals(segmentName)) {
         if (!field.repeatedField) {
           String value = readValue(fields, field.fieldPos, field.subPos);
-          value = varyName(value);
+          value = varyName(value, field);
           updateValue(value, fields, field.fieldPos, field.subPos);
         } else {
           String[] repeatFields = readRepeats(fields, field.fieldPos);
@@ -52,7 +52,7 @@ public class AddVariation extends ProcedureCommon implements ProcedureInterface 
           for (String value : repeatFields) {
             String email = readRepeatValue(value, field.subPos);
             if (email.indexOf('@') > 0) {
-              email = varyName(email);
+              email = varyName(email, field);
               updateRepeat(email, repeatFields, pos, field.subPos);
             }
             pos++;
@@ -66,7 +66,7 @@ public class AddVariation extends ProcedureCommon implements ProcedureInterface 
     putMessageBackTogether(transformRequest, fieldsList);
   }
 
-  protected static String varyName(String name) {
+  protected static String varyName(String name, Field field) {
     if (name.startsWith("'") || name.endsWith("'")) {
       return name;
     }
@@ -88,12 +88,17 @@ public class AddVariation extends ProcedureCommon implements ProcedureInterface 
         pos = findFirstConsonantAfterVowel(name);
       }
       if (pos > 0 && pos < name.length()) {
-        if (System.currentTimeMillis() % 2 == 0) {
+        if (field == Field.EMAIL || System.currentTimeMillis() % 2 == 0) {
+          // do not add a space to the email
           name = name.substring(0, pos) + "'" + capitalizeFirst(name.substring(pos));
         } else {
           name = name.substring(0, pos) + " " + capitalizeFirst(name.substring(pos));
         }
       }
+    }
+
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
     }
 
     if (upperCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/AlternativeBeginnings.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/AlternativeBeginnings.java
@@ -45,7 +45,7 @@ public class AlternativeBeginnings extends ProcedureCommon implements ProcedureI
       if ("PID".equals(segmentName)) {
         if (!field.repeatedField) {
           String value = readValue(fields, field.fieldPos, field.subPos);
-          value = varyName(value);
+          value = varyName(value, field);
           updateValue(value, fields, field.fieldPos, field.subPos);
         } else {
           String[] repeatFields = readRepeats(fields, field.fieldPos);
@@ -53,7 +53,7 @@ public class AlternativeBeginnings extends ProcedureCommon implements ProcedureI
           for (String value : repeatFields) {
             String email = readRepeatValue(value, field.subPos);
             if (email.indexOf('@') > 0) {
-              email = varyName(email);
+              email = varyName(email, field);
               updateRepeat(email, repeatFields, pos, field.subPos);
             }
             pos++;
@@ -67,7 +67,7 @@ public class AlternativeBeginnings extends ProcedureCommon implements ProcedureI
     putMessageBackTogether(transformRequest, fieldsList);
   }
 
-  protected static String varyName(String name) {
+  protected static String varyName(String name, Field field) {
     boolean upperCase = name.toUpperCase().equals(name);
     boolean lowerCase = name.toLowerCase().equals(name);
 
@@ -79,6 +79,10 @@ public class AlternativeBeginnings extends ProcedureCommon implements ProcedureI
         name = replacingWith + nameLower.substring(lookingFor.length());
         break;
       }
+    }
+
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
     }
 
     if (upperCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/AlternativeEndingVowels.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/AlternativeEndingVowels.java
@@ -121,6 +121,9 @@ public class AlternativeEndingVowels extends ProcedureCommon implements Procedur
         case LAST_NAME:
         case MOTHERS_MAIDEN_NAME:
         case ADDRESS_STREET:
+          name = ALTERNATIVE_LAST_NAMES.get(random.nextInt(ALTERNATIVE_LAST_NAMES.size()));
+          break;
+
         case EMAIL:
           name = ALTERNATIVE_LAST_NAMES.get(random.nextInt(ALTERNATIVE_LAST_NAMES.size()));
           break;
@@ -145,6 +148,7 @@ public class AlternativeEndingVowels extends ProcedureCommon implements Procedur
     } else if (field == Field.EMAIL && StringUtils.isNotBlank(originalName)) {
       name = name.replace(" ", ".").replace("'", ".")
           + originalName.substring(originalName.indexOf("@"));
+      name = makeEmailValid(name);
     }
 
     if (upperCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/AlternativeEndings.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/AlternativeEndings.java
@@ -45,7 +45,7 @@ public class AlternativeEndings extends ProcedureCommon implements ProcedureInte
       if ("PID".equals(segmentName)) {
         if (!field.repeatedField) {
           String value = readValue(fields, field.fieldPos, field.subPos);
-          value = varyName(value);
+          value = varyName(value, field);
           updateValue(value, fields, field.fieldPos, field.subPos);
         } else {
           String[] repeatFields = readRepeats(fields, field.fieldPos);
@@ -53,7 +53,7 @@ public class AlternativeEndings extends ProcedureCommon implements ProcedureInte
           for (String value : repeatFields) {
             String email = readRepeatValue(value, field.subPos);
             if (email.indexOf('@') > 0) {
-              email = varyName(email);
+              email = varyName(email, field);
               updateRepeat(email, repeatFields, pos, field.subPos);
             }
             pos++;
@@ -67,7 +67,7 @@ public class AlternativeEndings extends ProcedureCommon implements ProcedureInte
     putMessageBackTogether(transformRequest, fieldsList);
   }
 
-  protected static String varyName(String name) {
+  protected static String varyName(String name, Field field) {
     boolean upperCase = name.toUpperCase().equals(name);
     boolean lowerCase = name.toLowerCase().equals(name);
 
@@ -82,6 +82,10 @@ public class AlternativeEndings extends ProcedureCommon implements ProcedureInte
             + punctuation;
         break;
       }
+    }
+
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
     }
 
     if (upperCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/AlternativeVowels.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/AlternativeVowels.java
@@ -46,7 +46,7 @@ public class AlternativeVowels extends ProcedureCommon implements ProcedureInter
       if ("PID".equals(segmentName)) {
         if (!field.repeatedField) {
           String value = readValue(fields, field.fieldPos, field.subPos);
-          value = varyName(value, transformer);
+          value = varyName(value, transformer, field);
           updateValue(value, fields, field.fieldPos, field.subPos);
         } else {
           String[] repeatFields = readRepeats(fields, field.fieldPos);
@@ -54,7 +54,7 @@ public class AlternativeVowels extends ProcedureCommon implements ProcedureInter
           for (String value : repeatFields) {
             String email = readRepeatValue(value, field.subPos);
             if (email.indexOf('@') > 0) {
-              email = varyName(email, transformer);
+              email = varyName(email, transformer, field);
               updateRepeat(email, repeatFields, pos, field.subPos);
             }
             pos++;
@@ -68,7 +68,7 @@ public class AlternativeVowels extends ProcedureCommon implements ProcedureInter
     putMessageBackTogether(transformRequest, fieldsList);
   }
 
-  protected static String varyName(String name, Transformer transformer) {
+  protected static String varyName(String name, Transformer transformer, Field field) {
     boolean upperCase = name.toUpperCase().equals(name);
     boolean lowerCase = name.toLowerCase().equals(name);
 
@@ -88,6 +88,10 @@ public class AlternativeVowels extends ProcedureCommon implements ProcedureInter
 
         break;
       }
+    }
+
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
     }
 
     if (upperCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/HyphenateVariation.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/HyphenateVariation.java
@@ -129,6 +129,11 @@ public class HyphenateVariation extends ProcedureCommon implements ProcedureInte
         }
       }
     }
+
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
+    }
+
     if (upperCase) {
       name = name.toUpperCase();
     } else if (lowerCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/ProcedureCommon.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/ProcedureCommon.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
 import org.immregistries.smm.transform.TransformRequest;
 
@@ -270,5 +271,66 @@ public abstract class ProcedureCommon implements ProcedureInterface {
       address = address.toLowerCase();
     }
     return address;
+  }
+
+  // https://www.baeldung.com/java-email-validation-regex
+  protected static String makeEmailValid(String email) {
+    if (StringUtils.isBlank(email)) {
+      return "";
+    }
+
+    // eliminate spaces
+    email = email.replace(" ", "");
+    email = email.replace("\t", "");
+    email = email.replace("\r\n", "");
+    email = email.replace("\n", "");
+
+    String[] parts = email.split("\\@");
+
+    String local = parts[0].trim();
+
+    // local can't start with period
+    while (local.startsWith(".")) {
+      local = local.substring(1).trim();
+    }
+
+    // local can't end with period
+    while (local.endsWith(".")) {
+      local = local.substring(0, local.length() - 1).trim();
+    }
+
+    // local can't contain consecutive dots
+    while (local.contains("..")) {
+      local = local.replace("..", ".").trim();
+    }
+
+    // local has to be 64 characters or less
+    local = StringUtils.truncate(local, 64);
+
+    String domain;
+
+    // create the domain part since there's no @ sign
+    if (parts.length == 1) {
+      domain = "gmail.com";
+    } else {
+      domain = parts[1];
+    }
+
+    // domain can't start with period
+    while (domain.startsWith(".") || domain.startsWith("-")) {
+      domain = domain.substring(1).trim();
+    }
+
+    // domain can't end with period
+    while (domain.endsWith(".") || domain.endsWith("-")) {
+      domain = domain.substring(0, domain.length() - 1).trim();
+    }
+
+    // domain can't contain consecutive dots
+    while (domain.contains("..")) {
+      domain = domain.replace("..", ".").trim();
+    }
+
+    return local + "@" + domain;
   }
 }

--- a/src/main/java/org/immregistries/smm/transform/procedure/RepeatedConsonants.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/RepeatedConsonants.java
@@ -44,7 +44,7 @@ public class RepeatedConsonants extends ProcedureCommon implements ProcedureInte
       if ("PID".equals(segmentName)) {
         if (!field.repeatedField) {
           String value = readValue(fields, field.fieldPos, field.subPos);
-          value = varyName(value, transformer);
+          value = varyName(value, transformer, field);
           updateValue(value, fields, field.fieldPos, field.subPos);
         } else {
           int fieldPos = 13;
@@ -55,7 +55,7 @@ public class RepeatedConsonants extends ProcedureCommon implements ProcedureInte
 
             String email = readRepeatValue(value, subPos);
             if (email.indexOf('@') > 0) {
-              email = varyName(email, transformer);
+              email = varyName(email, transformer, field);
               updateRepeat(email, repeatFields, pos, subPos);
             }
             pos++;
@@ -74,20 +74,24 @@ public class RepeatedConsonants extends ProcedureCommon implements ProcedureInte
       'p', 'r', 's', 't', 'b', 'c', 'd', 'f', 'g', 'l', 'm', 'n', 'p', 'r', 's', 't', 'b', 'c', 'd',
       'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 't', 'v', 'w', 'y', 'z'};
 
-  protected static String varyName(String name, Transformer transformer) {
+  protected static String varyName(String name, Transformer transformer, Field field) {
     boolean upperCase = name.toUpperCase().equals(name);
     boolean lowerCase = name.toLowerCase().equals(name);
 
     Random random = transformer.getRandom();
 
     String nameLower = name.toLowerCase();
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 500; i++) {
       char c = REPEATABLE_CONSONANTS[random.nextInt(REPEATABLE_CONSONANTS.length)];
       int pos = nameLower.indexOf(c);
       if (pos > 0) {
         name = nameLower.substring(0, pos) + c + nameLower.substring(pos);
         break;
       }
+    }
+
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
     }
 
     if (upperCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/SpecialCharacters.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/SpecialCharacters.java
@@ -107,6 +107,10 @@ public class SpecialCharacters extends ProcedureCommon implements ProcedureInter
       name = name.substring(0, pos) + diacritic + name.substring(pos + 1);
     }
 
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
+    }
+
     if (upperCase) {
       name = name.toUpperCase();
     } else if (lowerCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/TextChange.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/TextChange.java
@@ -82,33 +82,46 @@ public class TextChange extends ProcedureCommon implements ProcedureInterface {
   }
 
   protected static String varyText(String value, Field field, Transformer transformer) {
+    String originalValue = value;
     boolean upperCase = value.toUpperCase().equals(value);
     boolean lowerCase = value.toLowerCase().equals(value);
     Random random = transformer.getRandom();
 
-    switch (field) {
-      case FIRST_NAME:
-      case MIDDLE_NAME:
-        value = transformer.getRandomValue(random.nextBoolean() ? "GIRL" : "BOY");
-        break;
-      case LAST_NAME:
-      case MOTHERS_MAIDEN_NAME:
-        value = transformer.getRandomValue("LAST_NAME");
-        break;
-      case MOTHERS_FIRST_NAME:
-        value = transformer.getRandomValue("GIRL");
-        break;
-      case ADDRESS_CITY:
-        value = transformer.getRandomValue("ADDRESS");
-        break;
-      case EMAIL:
-        value = transformer.getRandomValue("GIRL") + "." + transformer.getRandomValue("LAST_NAME")
-            + random.nextInt(2500) + "@" + transformer.getRandomValue("LAST_NAME") + ".com";
-        break;
-      case PHONE:
-        value = "" + (random.nextInt(8) + 2) + random.nextInt(10) + random.nextInt(10)
-            + random.nextInt(10) + random.nextInt(10) + random.nextInt(10) + random.nextInt(10);
-        break;
+    boolean notDifferent = true;
+    int count = 0;
+
+    while (notDifferent && count < 10) {
+      switch (field) {
+        case FIRST_NAME:
+        case MIDDLE_NAME:
+          value = transformer.getRandomValue(random.nextBoolean() ? "GIRL" : "BOY");
+          break;
+        case LAST_NAME:
+        case MOTHERS_MAIDEN_NAME:
+          value = transformer.getRandomValue("LAST_NAME");
+          break;
+        case MOTHERS_FIRST_NAME:
+          value = transformer.getRandomValue("GIRL");
+          break;
+        case ADDRESS_CITY:
+          value = transformer.getRandomValue("ADDRESS");
+          break;
+        case EMAIL:
+          value = transformer.getRandomValue("GIRL") + "." + transformer.getRandomValue("LAST_NAME")
+              + random.nextInt(2500) + "@" + transformer.getRandomValue("LAST_NAME") + ".com";
+          value = makeEmailValid(value);
+          break;
+        case PHONE:
+          value = "" + (random.nextInt(8) + 2) + random.nextInt(10) + random.nextInt(10)
+              + random.nextInt(10) + random.nextInt(10) + random.nextInt(10) + random.nextInt(10);
+          break;
+      }
+
+      // try really hard to get a different value
+      if (!originalValue.equals(value)) {
+        notDifferent = false;
+      }
+      count++;
     }
 
     if (upperCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/TextLetterToNumberTypo.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/TextLetterToNumberTypo.java
@@ -46,6 +46,10 @@ public class TextLetterToNumberTypo extends AbstractTypoProcedure {
       name = name.substring(0, pos) + ("" + typo).toLowerCase() + name.substring(pos + 1);
     }
 
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
+    }
+
     if (upperCase) {
       name = name.toUpperCase();
     } else if (lowerCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/TextNumberToLetterTypo.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/TextNumberToLetterTypo.java
@@ -46,6 +46,10 @@ public class TextNumberToLetterTypo extends AbstractTypoProcedure {
       name = name.substring(0, pos) + ("" + typo).toLowerCase() + name.substring(pos + 1);
     }
 
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
+    }
+
     if (upperCase) {
       name = name.toUpperCase();
     } else if (lowerCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/TextRandomTypo.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/TextRandomTypo.java
@@ -7,6 +7,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.immregistries.smm.transform.TransformRequest;
 import org.immregistries.smm.transform.Transformer;
+import org.immregistries.smm.transform.procedure.AbstractTypoProcedure.Field;
 
 public class TextRandomTypo extends ProcedureCommon implements ProcedureInterface {
 
@@ -17,10 +18,7 @@ public class TextRandomTypo extends ProcedureCommon implements ProcedureInterfac
   AbstractTypoProcedure.Field field;
   private Transformer transformer;
 
-  @Override
-  public void doProcedure(TransformRequest transformRequest, LinkedList<String> tokenList)
-      throws IOException {
-
+  private List<AbstractTypoProcedure> getTypoProceduresInRandomOrder() {
     // produce a random order of typo procedures
     List<AbstractTypoProcedure> typoProcs = new ArrayList<>();
     typoProcs.add(new TextTypo(field));
@@ -29,11 +27,18 @@ public class TextRandomTypo extends ProcedureCommon implements ProcedureInterfac
     typoProcs.add(new TextNumberToLetterTypo(field));
     Collections.shuffle(typoProcs);
 
+    return typoProcs;
+  }
+
+  @Override
+  public void doProcedure(TransformRequest transformRequest, LinkedList<String> tokenList)
+      throws IOException {
+
     // save the original text, we want to actually try to have a typo happen
     // so that means trying all the procedures until the result changes
     String before = transformRequest.getResultText();
 
-    for (AbstractTypoProcedure proc : typoProcs) {
+    for (AbstractTypoProcedure proc : getTypoProceduresInRandomOrder()) {
       proc.setTransformer(transformer);
       proc.doProcedure(transformRequest, tokenList);
       String after = transformRequest.getResultText();
@@ -42,6 +47,24 @@ public class TextRandomTypo extends ProcedureCommon implements ProcedureInterfac
         break;
       }
     }
+  }
+
+  // only used for testing at the moment
+  protected String varyText(String name, Transformer transformer) {
+    for (AbstractTypoProcedure proc : getTypoProceduresInRandomOrder()) {
+      String after = proc.varyText(name, transformer);
+
+      if (field == Field.EMAIL) {
+        name = makeEmailValid(name);
+      }
+
+      if (!name.equals(after)) {
+        // got a typo, so break out
+        return after;
+      }
+    }
+
+    return name;
   }
 
   @Override

--- a/src/main/java/org/immregistries/smm/transform/procedure/TextTransposeTypo.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/TextTransposeTypo.java
@@ -35,6 +35,10 @@ public class TextTransposeTypo extends AbstractTypoProcedure {
       name = name.substring(0, pos) + secondLetter + firstLetter + name.substring(pos + 2);
     }
 
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
+    }
+
     if (upperCase) {
       name = name.toUpperCase();
     } else if (lowerCase) {

--- a/src/main/java/org/immregistries/smm/transform/procedure/TextTypo.java
+++ b/src/main/java/org/immregistries/smm/transform/procedure/TextTypo.java
@@ -28,6 +28,9 @@ public class TextTypo extends AbstractTypoProcedure {
     char typo = typoes.charAt(transformer.getRandom().nextInt(typoes.length()));
     name = name.substring(0, pos) + ("" + typo).toLowerCase() + name.substring(pos + 1);
 
+    if (field == Field.EMAIL) {
+      name = makeEmailValid(name);
+    }
 
     if (upperCase) {
       name = name.toUpperCase();

--- a/src/test/java/org/immregistries/smm/transform/procedure/AddVariationTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/AddVariationTest.java
@@ -3,84 +3,102 @@ package org.immregistries.smm.transform.procedure;
 import static org.junit.Assert.assertNotEquals;
 import java.util.Arrays;
 import java.util.List;
+import org.immregistries.smm.transform.procedure.AddVariation.Field;
 import org.junit.Test;
 
 public class AddVariationTest extends ProcedureCommonTest {
 
-
   @Test
   public void test() {
-    List<List<String>> locationProcedurePairs =
-        Arrays.asList(Arrays.asList("PID-5.1", ProcedureFactory.LAST_NAME_ADD_VARIATION),
-            Arrays.asList("PID-5.2", ProcedureFactory.FIRST_NAME_ADD_VARIATION),
-            Arrays.asList("PID-5.3", ProcedureFactory.MIDDLE_NAME_ADD_VARIATION),
-            Arrays.asList("PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_ADD_VARIATION),
-            Arrays.asList("PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_ADD_VARIATION),
-            Arrays.asList("PID-11.1", ProcedureFactory.ADDRESS_STREET_ADD_VARIATION),
-            Arrays.asList("PID-11.3", ProcedureFactory.ADDRESS_CITY_ADD_VARIATION));
+    List<Triplet> triplets = Arrays.asList(
+        new Triplet("PID-5.1", ProcedureFactory.LAST_NAME_ADD_VARIATION, Field.LAST_NAME),
+        new Triplet("PID-5.2", ProcedureFactory.FIRST_NAME_ADD_VARIATION, Field.FIRST_NAME),
+        new Triplet("PID-5.3", ProcedureFactory.MIDDLE_NAME_ADD_VARIATION, Field.MIDDLE_NAME),
+        new Triplet("PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_ADD_VARIATION,
+            Field.MOTHERS_MAIDEN_NAME),
+        new Triplet("PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_ADD_VARIATION,
+            Field.MOTHERS_FIRST_NAME),
+        new Triplet("PID-11.1", ProcedureFactory.ADDRESS_STREET_ADD_VARIATION,
+            Field.ADDRESS_STREET),
+        new Triplet("PID-11.3", ProcedureFactory.ADDRESS_CITY_ADD_VARIATION, Field.ADDRESS_CITY));
 
-    for (List<String> pair : locationProcedurePairs) {
-      String location = pair.get(0);
-      String procedure = pair.get(1);
+    for (int i = 0; i < 100; i++) {
+      for (Triplet trip : triplets) {
+        testVariation("De'Shawn", "DeShawn", trip.location, trip.procedure, trip.field);
+        testVariation("De Shawn", "DeShawn", trip.location, trip.procedure, trip.field);
+        testVariation("DeShawn", "De'Shawn", "De Shawn", trip.location, trip.procedure, trip.field);
+        testVariation("Deshawn", "De'Shawn", "De Shawn", trip.location, trip.procedure, trip.field);
+        testVariation("DesHawn", "Des'Hawn", "Des Hawn", trip.location, trip.procedure, trip.field);
+        testVariation("DESHAWN", "DE'SHAWN", "DE SHAWN", trip.location, trip.procedure, trip.field);
+        testVariation("Anne", "A'Nne", "A Nne", trip.location, trip.procedure, trip.field);
+        testVariation("May", "Ma'Y", "Ma Y", trip.location, trip.procedure, trip.field);
+        testVariation("Bee", "Bee", trip.location, trip.procedure, trip.field);
+        testVariation("Neelima", "Nee'Lima", "Nee Lima", trip.location, trip.procedure, trip.field);
+        testVariation("Be e", "BeE", trip.location, trip.procedure, trip.field);
+        testVariation("Peter", "Pe'Ter", "Pe Ter", trip.location, trip.procedure, trip.field);
+        testVariation("O'Henry", "OHenry", trip.location, trip.procedure, trip.field);
+        testVariation("O Henry", "OHenry", trip.location, trip.procedure, trip.field);
+        testVariation("OHenry", "O'Henry", "O Henry", trip.location, trip.procedure, trip.field);
+        testVariation("Deuteaux", "Deu'Teaux", "Deu Teaux", trip.location, trip.procedure,
+            trip.field);
+        testVariation("'DeShawn", "'DeShawn", trip.location, trip.procedure, trip.field);
+        testVariation("DeShawn'", "DeShawn'", trip.location, trip.procedure, trip.field);
+        testVariation("DeShaw'n", "DeShawN", trip.location, trip.procedure, trip.field);
+        testVariation("D'eShawn", "DEShawn", trip.location, trip.procedure, trip.field);
 
-      testVariation("De'Shawn", "DeShawn", location, procedure);
-      testVariation("De Shawn", "DeShawn", location, procedure);
-      testVariation("DeShawn", "De'Shawn", "De Shawn", location, procedure);
-      testVariation("Deshawn", "De'Shawn", "De Shawn", location, procedure);
-      testVariation("DesHawn", "Des'Hawn", "Des Hawn", location, procedure);
-      testVariation("DESHAWN", "DE'SHAWN", "DE SHAWN", location, procedure);
-      testVariation("Anne", "A'Nne", "A Nne", location, procedure);
-      testVariation("May", "Ma'Y", "Ma Y", location, procedure);
-      testVariation("Bee", "Bee", location, procedure);
-      testVariation("Neelima", "Nee'Lima", "Nee Lima", location, procedure);
-      testVariation("Be e", "BeE", location, procedure);
-      testVariation("Peter", "Pe'Ter", "Pe Ter", location, procedure);
-      testVariation("O'Henry", "OHenry", location, procedure);
-      testVariation("O Henry", "OHenry", location, procedure);
-      testVariation("OHenry", "O'Henry", "O Henry", location, procedure);
-      testVariation("Deuteaux", "Deu'Teaux", "Deu Teaux", location, procedure);
-      testVariation("'DeShawn", "'DeShawn", location, procedure);
-      testVariation("DeShawn'", "DeShawn'", location, procedure);
-      testVariation("DeShaw'n", "DeShawN", location, procedure);
-      testVariation("D'eShawn", "DEShawn", location, procedure);
+        testVariation("New York City", "NewYork City", trip.location, trip.procedure, trip.field);
+        testVariation("505 Radio Drive", "505Radio Drive", trip.location, trip.procedure,
+            trip.field);
+        testVariation("1234 East Circle Dr.", "1234East Circle Dr.", trip.location, trip.procedure,
+            trip.field);
+        testVariation("Martha's Vineyard", "MarthaS Vineyard", trip.location, trip.procedure,
+            trip.field);
+        testVariation("Po'ipu", "PoIpu", trip.location, trip.procedure, trip.field);
+        testVariation("", "", trip.location, trip.procedure, trip.field);
+      }
 
-      testVariation("New York City", "NewYork City", location, procedure);
-      testVariation("505 Radio Drive", "505Radio Drive", location, procedure);
-      testVariation("1234 East Circle Dr.", "1234East Circle Dr.", location, procedure);
-      testVariation("Martha's Vineyard", "MarthaS Vineyard", location, procedure);
-      testVariation("Po'ipu", "PoIpu", location, procedure);
-      testVariation("", "", location, procedure);
+      testDifferent("bob@comcast.net", "bob'@comcast.net", "PID-13.4",
+          ProcedureFactory.EMAIL_ADD_VARIATION, Field.EMAIL);
     }
-
-    testDifferent("bob@comcast.net", "bob'@comcast.net", "bob @comcast.net", "PID-13.4",
-        ProcedureFactory.EMAIL_ADD_VARIATION);
   }
 
   private void testVariation(String startValue, String endValueExpected, String location,
-      String procedure) {
-    String endValueActual = AddVariation.varyName(startValue);
+      String procedure, Field field) {
+    String endValueActual = AddVariation.varyName(startValue, field);
     assertEquals(endValueExpected, endValueActual);
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     String testEnd = transform(DEFAULT_TEST_MESSAGE, location + "=" + endValueExpected);
     testEquals(testStart, testEnd, procedure);
   }
 
-  private void testDifferent(String startValue, String endValue1, String endValue2, String location,
-      String procedure) {
-    String endValue = AddVariation.varyName(startValue);
-    assertTrue(endValue.equals(endValue1) || endValue.equals(endValue2));
+  private void testDifferent(String startValue, String endValue1, String location, String procedure,
+      Field field) {
+    String endValue = AddVariation.varyName(startValue, field);
+    assertEquals(endValue1, endValue);
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     String after = processProcedureChangesMessage(testStart, procedure);
     assertNotEquals(testStart, after);
   }
 
   private void testVariation(String startValue, String endValue1, String endValue2, String location,
-      String procedure) {
-    String endValue = AddVariation.varyName(startValue);
+      String procedure, Field field) {
+    String endValue = AddVariation.varyName(startValue, field);
     assertTrue(endValue.equals(endValue1) || endValue.equals(endValue2));
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     String testEnd1 = transform(DEFAULT_TEST_MESSAGE, location + "=" + endValue1);
     String testEnd2 = transform(DEFAULT_TEST_MESSAGE, location + "=" + endValue2);
     testEquals(testStart, testEnd1, testEnd2, procedure);
+  }
+
+  private class Triplet {
+    String location;
+    String procedure;
+    Field field;
+
+    Triplet(String location, String procedure, Field field) {
+      this.location = location;
+      this.procedure = procedure;
+      this.field = field;
+    }
   }
 }

--- a/src/test/java/org/immregistries/smm/transform/procedure/AlternativeBeginningsTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/AlternativeBeginningsTest.java
@@ -1,162 +1,171 @@
 package org.immregistries.smm.transform.procedure;
 
 import static org.junit.Assert.assertNotEquals;
+import org.immregistries.smm.transform.procedure.AlternativeBeginnings.Field;
 import org.junit.Test;
 
 public class AlternativeBeginningsTest extends ProcedureCommonTest {
-
 
   @Test
   public void test() {
     String location = "PID-5.1";
     String procedure = ProcedureFactory.LAST_NAME_ALTERNATIVE_BEGINNINGS;
+    Field field = Field.LAST_NAME;
 
-    testVariation("Christopher", "Kristopher", location, procedure);
-    testVariation("Spletzer", "Pletzer", location, procedure);
-    testVariation("Squib", "Quib", location, procedure);
-    testVariation("Thraselton", "Fraselton", location, procedure);
-    testVariation("Bland", "Land", location, procedure);
-    testVariation("Brown", "Rown", location, procedure);
-    testVariation("Fleckner", "Leckner", location, procedure);
-    testVariation("Fraselton", "Thaselton", location, procedure);
-    testVariation("Klaus", "Laus", location, procedure);
-    testVariation("Proud", "Roud", location, procedure);
-    testVariation("Schrute", "Chrute", location, procedure);
-    testVariation("Skellig", "Cellig", location, procedure);
-    testVariation("Spratt", "Pratt", location, procedure);
-    testVariation("Stclair", "Tclair", location, procedure);
-    testVariation("Swartzman", "Wartzman", location, procedure);
-    testVariation("Thaselton", "Faselton", location, procedure);
-    testVariation("Twanbly", "Wanbly", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Christopher", "Kristopher", location, procedure, field);
+    testVariation("Spletzer", "Pletzer", location, procedure, field);
+    testVariation("Squib", "Quib", location, procedure, field);
+    testVariation("Thraselton", "Fraselton", location, procedure, field);
+    testVariation("Bland", "Land", location, procedure, field);
+    testVariation("Brown", "Rown", location, procedure, field);
+    testVariation("Fleckner", "Leckner", location, procedure, field);
+    testVariation("Fraselton", "Thaselton", location, procedure, field);
+    testVariation("Klaus", "Laus", location, procedure, field);
+    testVariation("Proud", "Roud", location, procedure, field);
+    testVariation("Schrute", "Chrute", location, procedure, field);
+    testVariation("Skellig", "Cellig", location, procedure, field);
+    testVariation("Spratt", "Pratt", location, procedure, field);
+    testVariation("Stclair", "Tclair", location, procedure, field);
+    testVariation("Swartzman", "Wartzman", location, procedure, field);
+    testVariation("Thaselton", "Faselton", location, procedure, field);
+    testVariation("Twanbly", "Wanbly", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-5.2";
     procedure = ProcedureFactory.FIRST_NAME_ALTERNATIVE_BEGINNINGS;
+    field = Field.FIRST_NAME;
 
-    testVariation("Sam", "Tsam", location, procedure);
-    testVariation("Liam", "Jiam", location, procedure);
-    testVariation("Noah", "Moah", location, procedure);
-    testVariation("Oliver", "Aliver", location, procedure);
-    testVariation("Elijah", "Alijah", location, procedure);
-    testVariation("James", "Games", location, procedure);
-    testVariation("William", "Villiam", location, procedure);
-    testVariation("Benjamin", "Venjamin", location, procedure);
-    testVariation("Lucas", "Jucas", location, procedure);
-    testVariation("Henry", "Venry", location, procedure);
-    testVariation("Olivia", "Alivia", location, procedure);
-    testVariation("Emma", "Amma", location, procedure);
-    testVariation("Charlotte", "Sarlotte", location, procedure);
-    testVariation("Amelia", "Emelia", location, procedure);
-    testVariation("Ava", "Eva", location, procedure);
-    testVariation("Sophia", "Tsophia", location, procedure);
-    testVariation("Isabella", "Esabella", location, procedure);
-    testVariation("Mia", "Nia", location, procedure);
-    testVariation("Evelyn", "Avelyn", location, procedure);
-    testVariation("Harper", "Varper", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Sam", "Tsam", location, procedure, field);
+    testVariation("Liam", "Jiam", location, procedure, field);
+    testVariation("Noah", "Moah", location, procedure, field);
+    testVariation("Oliver", "Aliver", location, procedure, field);
+    testVariation("Elijah", "Alijah", location, procedure, field);
+    testVariation("James", "Games", location, procedure, field);
+    testVariation("William", "Villiam", location, procedure, field);
+    testVariation("Benjamin", "Venjamin", location, procedure, field);
+    testVariation("Lucas", "Jucas", location, procedure, field);
+    testVariation("Henry", "Venry", location, procedure, field);
+    testVariation("Olivia", "Alivia", location, procedure, field);
+    testVariation("Emma", "Amma", location, procedure, field);
+    testVariation("Charlotte", "Sarlotte", location, procedure, field);
+    testVariation("Amelia", "Emelia", location, procedure, field);
+    testVariation("Ava", "Eva", location, procedure, field);
+    testVariation("Sophia", "Tsophia", location, procedure, field);
+    testVariation("Isabella", "Esabella", location, procedure, field);
+    testVariation("Mia", "Nia", location, procedure, field);
+    testVariation("Evelyn", "Avelyn", location, procedure, field);
+    testVariation("Harper", "Varper", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-5.3";
     procedure = ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_BEGINNINGS;
+    field = Field.MIDDLE_NAME;
 
-    testVariation("Clark", "Klark", location, procedure);
-    testVariation("Crow", "Krow", location, procedure);
-    testVariation("Drake", "Trake", location, procedure);
-    testVariation("Dwight", "Twight", location, procedure);
-    testVariation("Glass", "Lass", location, procedure);
-    testVariation("Grass", "Gass", location, procedure);
-    testVariation("Krow", "Chrow", location, procedure);
-    testVariation("Plaza", "Laza", location, procedure);
-    testVariation("Shane", "Thane", location, procedure);
-    testVariation("Slackford", "Lackford", location, procedure);
-    testVariation("Snore", "Nore", location, procedure);
-    testVariation("Stratford", "Tatford", location, procedure);
-    testVariation("Trill", "Rill", location, procedure);
-    testVariation("Wrtrykowski", "Rtrykowski", location, procedure);
-    testVariation("Quinn", "Kinn", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Clark", "Klark", location, procedure, field);
+    testVariation("Crow", "Krow", location, procedure, field);
+    testVariation("Drake", "Trake", location, procedure, field);
+    testVariation("Dwight", "Twight", location, procedure, field);
+    testVariation("Glass", "Lass", location, procedure, field);
+    testVariation("Grass", "Gass", location, procedure, field);
+    testVariation("Krow", "Chrow", location, procedure, field);
+    testVariation("Plaza", "Laza", location, procedure, field);
+    testVariation("Shane", "Thane", location, procedure, field);
+    testVariation("Slackford", "Lackford", location, procedure, field);
+    testVariation("Snore", "Nore", location, procedure, field);
+    testVariation("Stratford", "Tatford", location, procedure, field);
+    testVariation("Trill", "Rill", location, procedure, field);
+    testVariation("Wrtrykowski", "Rtrykowski", location, procedure, field);
+    testVariation("Quinn", "Kinn", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-6.1";
     procedure = ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_BEGINNINGS;
+    field = Field.MOTHERS_MAIDEN_NAME;
 
-    testVariation("Pastel", "Quastel", location, procedure);
-    testVariation("Sanders", "Tsanders", location, procedure);
-    testVariation("Xander", "Ekander", location, procedure);
-    testVariation("Yennifer", "Wennifer", location, procedure);
-    testVariation("Zozo", "Sozo", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Pastel", "Quastel", location, procedure, field);
+    testVariation("Sanders", "Tsanders", location, procedure, field);
+    testVariation("Xander", "Ekander", location, procedure, field);
+    testVariation("Yennifer", "Wennifer", location, procedure, field);
+    testVariation("Zozo", "Sozo", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-6.2";
     procedure = ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_BEGINNINGS;
+    field = Field.MOTHERS_FIRST_NAME;
 
-    testVariation("Olivia", "Alivia", location, procedure);
-    testVariation("Emma", "Amma", location, procedure);
-    testVariation("Charlotte", "Sarlotte", location, procedure);
-    testVariation("Amelia", "Emelia", location, procedure);
-    testVariation("Ava", "Eva", location, procedure);
-    testVariation("Sophia", "Tsophia", location, procedure);
-    testVariation("Isabella", "Esabella", location, procedure);
-    testVariation("Mia", "Nia", location, procedure);
-    testVariation("Evelyn", "Avelyn", location, procedure);
-    testVariation("Harper", "Varper", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Olivia", "Alivia", location, procedure, field);
+    testVariation("Emma", "Amma", location, procedure, field);
+    testVariation("Charlotte", "Sarlotte", location, procedure, field);
+    testVariation("Amelia", "Emelia", location, procedure, field);
+    testVariation("Ava", "Eva", location, procedure, field);
+    testVariation("Sophia", "Tsophia", location, procedure, field);
+    testVariation("Isabella", "Esabella", location, procedure, field);
+    testVariation("Mia", "Nia", location, procedure, field);
+    testVariation("Evelyn", "Avelyn", location, procedure, field);
+    testVariation("Harper", "Varper", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-11.1";
     procedure = ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_BEGINNINGS;
+    field = Field.ADDRESS_STREET;
 
-    testVariation("555 Crescent Ln.", "655 Crescent Ln.", location, procedure);
-    testVariation("1000 North La Sierra Dr.", "2000 North La Sierra Dr.", location, procedure);
-    testVariation("808 Beechwood Drive", "908 Beechwood Drive", location, procedure);
-    testVariation("W984 Gainsway Ave", "V984 Gainsway Ave", location, procedure);
-    testVariation("N9655 Denning Road", "M9655 Denning Road", location, procedure);
-    testVariation("12 Glen Ridge Blvd.", "22 Glen Ridge Blvd.", location, procedure);
-    testVariation("100a Bohemia Circle", "200a Bohemia Circle", location, procedure);
-    testVariation("988112 Albany Street", "088112 Albany Street", location, procedure);
-    testVariation("16 Abbey Rd.", "26 Abbey Rd.", location, procedure);
-    testVariation("5 Shore Ave.", "6 Shore Ave.", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("555 Crescent Ln.", "655 Crescent Ln.", location, procedure, field);
+    testVariation("1000 North La Sierra Dr.", "2000 North La Sierra Dr.", location, procedure,
+        field);
+    testVariation("808 Beechwood Drive", "908 Beechwood Drive", location, procedure, field);
+    testVariation("W984 Gainsway Ave", "V984 Gainsway Ave", location, procedure, field);
+    testVariation("N9655 Denning Road", "M9655 Denning Road", location, procedure, field);
+    testVariation("12 Glen Ridge Blvd.", "22 Glen Ridge Blvd.", location, procedure, field);
+    testVariation("100a Bohemia Circle", "200a Bohemia Circle", location, procedure, field);
+    testVariation("988112 Albany Street", "088112 Albany Street", location, procedure, field);
+    testVariation("16 Abbey Rd.", "26 Abbey Rd.", location, procedure, field);
+    testVariation("5 Shore Ave.", "6 Shore Ave.", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-11.3";
     procedure = ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_BEGINNINGS;
+    field = Field.ADDRESS_CITY;
 
-    testVariation("Kansas City", "Cansas City", location, procedure);
-    testVariation("Chandler", "Sandler", location, procedure);
-    testVariation("Las Vegas", "Jas Vegas", location, procedure);
-    testVariation("Buffalo", "Vuffalo", location, procedure);
-    testVariation("Lexington-Fayette", "Jexington-Fayette", location, procedure);
-    testVariation("Minneapolis", "Ninneapolis", location, procedure);
-    testVariation("St. Paul", "T. Paul", location, procedure);
-    testVariation("North Hempstead", "Morth Hempstead", location, procedure);
-    testVariation("Nashville-Davidson", "Mashville-Davidson", location, procedure);
-    testVariation("Salt Lake City", "Tsalt Lake City", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Kansas City", "Cansas City", location, procedure, field);
+    testVariation("Chandler", "Sandler", location, procedure, field);
+    testVariation("Las Vegas", "Jas Vegas", location, procedure, field);
+    testVariation("Buffalo", "Vuffalo", location, procedure, field);
+    testVariation("Lexington-Fayette", "Jexington-Fayette", location, procedure, field);
+    testVariation("Minneapolis", "Ninneapolis", location, procedure, field);
+    testVariation("St. Paul", "T. Paul", location, procedure, field);
+    testVariation("North Hempstead", "Morth Hempstead", location, procedure, field);
+    testVariation("Nashville-Davidson", "Mashville-Davidson", location, procedure, field);
+    testVariation("Salt Lake City", "Tsalt Lake City", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-13.4";
     procedure = ProcedureFactory.EMAIL_ALTERNATIVE_BEGINNINGS;
+    field = Field.EMAIL;
 
     // random emails from randomlists.com
-    testDifferent("dwendlan@me.com", "twendlan@me.com", location, procedure);
-    testDifferent("lauronen@msn.com", "jauronen@msn.com", location, procedure);
-    testDifferent("wmszeliga@gmail.com", "vmszeliga@gmail.com", location, procedure);
-    testDifferent("isotopian@yahoo.com", "esotopian@yahoo.com", location, procedure);
-    testDifferent("osrin@att.net", "asrin@att.net", location, procedure);
-    testDifferent("paina@optonline.net", "quaina@optonline.net", location, procedure);
-    testDifferent("hamilton@gmail.com", "vamilton@gmail.com", location, procedure);
-    testDifferent("gboss@mac.com", "kboss@mac.com", location, procedure);
-    testDifferent("peoplesr@comcast.net", "queoplesr@comcast.net", location, procedure);
-    testDifferent("lipeng@gmail.com", "jipeng@gmail.com", location, procedure);
+    testDifferent("dwendlan@me.com", "twendlan@me.com", location, procedure, field);
+    testDifferent("lauronen@msn.com", "jauronen@msn.com", location, procedure, field);
+    testDifferent("wmszeliga@gmail.com", "vmszeliga@gmail.com", location, procedure, field);
+    testDifferent("isotopian@yahoo.com", "esotopian@yahoo.com", location, procedure, field);
+    testDifferent("osrin@att.net", "asrin@att.net", location, procedure, field);
+    testDifferent("paina@optonline.net", "quaina@optonline.net", location, procedure, field);
+    testDifferent("hamilton@gmail.com", "vamilton@gmail.com", location, procedure, field);
+    testDifferent("gboss@mac.com", "kboss@mac.com", location, procedure, field);
+    testDifferent("peoplesr@comcast.net", "queoplesr@comcast.net", location, procedure, field);
+    testDifferent("lipeng@gmail.com", "jipeng@gmail.com", location, procedure, field);
   }
 
-  private void testVariation(String startValue, String endValue, String location,
-      String procedure) {
-    assertEquals(endValue, AlternativeBeginnings.varyName(startValue));
+  private void testVariation(String startValue, String endValue, String location, String procedure,
+      Field field) {
+    assertEquals(endValue, AlternativeBeginnings.varyName(startValue, field));
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     String testEnd = transform(DEFAULT_TEST_MESSAGE, location + "=" + endValue);
     testEquals(testStart, testEnd, procedure);
   }
 
-  private void testDifferent(String startValue, String endValue, String location,
-      String procedure) {
-    assertEquals(endValue, AlternativeBeginnings.varyName(startValue));
+  private void testDifferent(String startValue, String endValue, String location, String procedure,
+      Field field) {
+    assertEquals(endValue, AlternativeBeginnings.varyName(startValue, field));
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     String after = processProcedureChangesMessage(testStart, procedure);
     assertNotEquals(testStart, after);

--- a/src/test/java/org/immregistries/smm/transform/procedure/AlternativeEndingVowelsTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/AlternativeEndingVowelsTest.java
@@ -11,113 +11,115 @@ public class AlternativeEndingVowelsTest extends ProcedureCommonTest {
   public void test() {
     Transformer t = new Transformer();
 
-    Field field = AlternativeEndingVowels.Field.FIRST_NAME;
-    testVariationDifferent("Amy", "PID-5.2", ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS,
-        t, field);
-    testVariationDifferent("Poe", "PID-5.2", ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS,
-        t, field);
-    testVariationDifferent("Beau", "PID-5.2", ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS,
-        t, field);
-    testVariationDifferent("Bob", "PID-5.2", ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS,
-        t, field);
-    testVariationDifferent("Richard", "PID-5.2",
-        ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("", "PID-5.2", ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t,
-        field);
+    for (int i = 0; i < 100; i++) {
+      Field field = AlternativeEndingVowels.Field.FIRST_NAME;
+      testVariationDifferent("Amy", "PID-5.2",
+          ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Poe", "PID-5.2",
+          ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Beau", "PID-5.2",
+          ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Bob", "PID-5.2",
+          ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Richard", "PID-5.2",
+          ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("", "PID-5.2", ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDING_VOWELS,
+          t, field);
 
-    field = AlternativeEndingVowels.Field.MIDDLE_NAME;
-    testVariationDifferent("Cathy", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Bill", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Suzy", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Joe", "PID-5.3", ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS,
-        t, field);
-    testVariationDifferent("Drew", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("", "PID-5.3", ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS, t,
-        field);
+      field = AlternativeEndingVowels.Field.MIDDLE_NAME;
+      testVariationDifferent("Cathy", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Bill", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Suzy", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Joe", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Drew", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("", "PID-5.3", ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDING_VOWELS,
+          t, field);
 
-    field = AlternativeEndingVowels.Field.LAST_NAME;
-    testVariationDifferent("Washington", "PID-5.1",
-        ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Terpi", "PID-5.1", ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS,
-        t, field);
-    testVariationDifferent("Fow", "PID-5.1", ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS,
-        t, field);
-    testVariationDifferent("Chiew", "PID-5.1", ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS,
-        t, field);
-    testVariationDifferent("Zruh", "PID-5.1", ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS,
-        t, field);
-    testVariationDifferent("", "PID-5.1", ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS, t,
-        field);
+      field = AlternativeEndingVowels.Field.LAST_NAME;
+      testVariationDifferent("Washington", "PID-5.1",
+          ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Terpi", "PID-5.1",
+          ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Fow", "PID-5.1", ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS,
+          t, field);
+      testVariationDifferent("Chiew", "PID-5.1",
+          ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Zruh", "PID-5.1",
+          ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("", "PID-5.1", ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDING_VOWELS, t,
+          field);
 
-    field = AlternativeEndingVowels.Field.MOTHERS_FIRST_NAME;
-    testVariationDifferent("Jess", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Sosoh", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Yoyieu", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Diedrah", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      field = AlternativeEndingVowels.Field.MOTHERS_FIRST_NAME;
+      testVariationDifferent("Jess", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Sosoh", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Yoyieu", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Diedrah", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
 
-    field = AlternativeEndingVowels.Field.MOTHERS_MAIDEN_NAME;
-    testVariationDifferent("Rogers", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("They", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Goe", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Shou", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Stella", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      field = AlternativeEndingVowels.Field.MOTHERS_MAIDEN_NAME;
+      testVariationDifferent("Rogers", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("They", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Goe", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Shou", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Stella", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDING_VOWELS, t, field);
 
-    field = AlternativeEndingVowels.Field.ADDRESS_STREET;
-    testVariationDifferent("100 MLK Dr.", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("1010 Bry St.", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("1600 Soho Ave.", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("N5144 Neau Parkway", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("1234 Teluh Blvd.", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDING_VOWELS, t, field);
+      field = AlternativeEndingVowels.Field.ADDRESS_STREET;
+      testVariationDifferent("100 MLK Dr.", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("1010 Bry St.", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("1600 Soho Ave.", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("N5144 Neau Parkway", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("1234 Teluh Blvd.", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDING_VOWELS, t, field);
 
-    field = AlternativeEndingVowels.Field.ADDRESS_CITY;
-    testVariationDifferent("Madison", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Derrie", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Dustow", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Bellvue", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("Tacomah", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("", "PID-11.3", ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS,
-        t, field);
+      field = AlternativeEndingVowels.Field.ADDRESS_CITY;
+      testVariationDifferent("Madison", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Derrie", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Dustow", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Bellvue", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("Tacomah", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDING_VOWELS, t, field);
 
-    field = AlternativeEndingVowels.Field.EMAIL;
-    testVariationDifferent("bob@gmail.com", "PID-13.4",
-        ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("evans.julie@gmail.com", "PID-13.4",
-        ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("stoh@aol.com", "PID-13.4",
-        ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("kidsoffue@msn.net", "PID-13.4",
-        ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("alameda@city.net", "PID-13.4",
-        ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t, field);
-    testVariationDifferent("", "PID-13.4", ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t,
-        field);
+      field = AlternativeEndingVowels.Field.EMAIL;
+      testVariationDifferent("bob@gmail.com", "PID-13.4",
+          ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("evans.julie@gmail.com", "PID-13.4",
+          ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("stoh@aol.com", "PID-13.4",
+          ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("kidsoffue@msn.net", "PID-13.4",
+          ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("alameda@city.net", "PID-13.4",
+          ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t, field);
+      testVariationDifferent("", "PID-13.4", ProcedureFactory.EMAIL_ALTERNATIVE_ENDING_VOWELS, t,
+          field);
+    }
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,

--- a/src/test/java/org/immregistries/smm/transform/procedure/AlternativeEndingsTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/AlternativeEndingsTest.java
@@ -1,6 +1,7 @@
 package org.immregistries.smm.transform.procedure;
 
 import static org.junit.Assert.assertNotEquals;
+import org.immregistries.smm.transform.procedure.AlternativeEndings.Field;
 import org.junit.Test;
 
 public class AlternativeEndingsTest extends ProcedureCommonTest {
@@ -10,134 +11,143 @@ public class AlternativeEndingsTest extends ProcedureCommonTest {
   public void test() {
     String location = "PID-5.1";
     String procedure = ProcedureFactory.LAST_NAME_ALTERNATIVE_ENDINGS;
+    Field field = Field.LAST_NAME;
 
-    testVariation("Brick", "Brikee", location, procedure);
-    testVariation("Benedict", "Beneditus", location, procedure);
-    testVariation("Swift", "Swiftee", location, procedure);
-    testVariation("Fairchild", "Fairchilder", location, procedure);
-    testVariation("Gandalf", "Gandalfie", location, procedure);
-    testVariation("Phelp", "Phelpy", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Brick", "Brikee", location, procedure, field);
+    testVariation("Benedict", "Beneditus", location, procedure, field);
+    testVariation("Swift", "Swiftee", location, procedure, field);
+    testVariation("Fairchild", "Fairchilder", location, procedure, field);
+    testVariation("Gandalf", "Gandalfie", location, procedure, field);
+    testVariation("Phelp", "Phelpy", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-5.2";
     procedure = ProcedureFactory.FIRST_NAME_ALTERNATIVE_ENDINGS;
+    field = Field.FIRST_NAME;
 
-    testVariation("Sam", "Sann", location, procedure);
-    testVariation("Liam", "Liann", location, procedure);
-    testVariation("Noah", "Noaph", location, procedure);
-    testVariation("Oliver", "Oliverrie", location, procedure);
-    testVariation("Elijah", "Elijaph", location, procedure);
-    testVariation("James", "Jamesz", location, procedure);
-    testVariation("William", "Williann", location, procedure);
-    testVariation("Benjamin", "Benjamimm", location, procedure);
-    testVariation("Lucas", "Lucasz", location, procedure);
-    testVariation("Henry", "Henrie", location, procedure);
-    testVariation("Olivia", "Oliviay", location, procedure);
-    testVariation("Emma", "Emmay", location, procedure);
-    testVariation("Charlotte", "Charlottee", location, procedure);
-    testVariation("Amelia", "Ameliay", location, procedure);
-    testVariation("Ava", "Avay", location, procedure);
-    testVariation("Sophia", "Sophiay", location, procedure);
-    testVariation("Isabella", "Isabellay", location, procedure);
-    testVariation("Mia", "Miay", location, procedure);
-    testVariation("Evelyn", "Evelymm", location, procedure);
-    testVariation("Harper", "Harperrie", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Sam", "Sann", location, procedure, field);
+    testVariation("Liam", "Liann", location, procedure, field);
+    testVariation("Noah", "Noaph", location, procedure, field);
+    testVariation("Oliver", "Oliverrie", location, procedure, field);
+    testVariation("Elijah", "Elijaph", location, procedure, field);
+    testVariation("James", "Jamesz", location, procedure, field);
+    testVariation("William", "Williann", location, procedure, field);
+    testVariation("Benjamin", "Benjamimm", location, procedure, field);
+    testVariation("Lucas", "Lucasz", location, procedure, field);
+    testVariation("Henry", "Henrie", location, procedure, field);
+    testVariation("Olivia", "Oliviay", location, procedure, field);
+    testVariation("Emma", "Emmay", location, procedure, field);
+    testVariation("Charlotte", "Charlottee", location, procedure, field);
+    testVariation("Amelia", "Ameliay", location, procedure, field);
+    testVariation("Ava", "Avay", location, procedure, field);
+    testVariation("Sophia", "Sophiay", location, procedure, field);
+    testVariation("Isabella", "Isabellay", location, procedure, field);
+    testVariation("Mia", "Miay", location, procedure, field);
+    testVariation("Evelyn", "Evelymm", location, procedure, field);
+    testVariation("Harper", "Harperrie", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-5.3";
     procedure = ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_ENDINGS;
+    field = Field.MIDDLE_NAME;
 
-    testVariation("Kemp", "Kempie", location, procedure);
-    testVariation("Armond", "Armody", location, procedure);
-    testVariation("Hank", "Haky", location, procedure);
-    testVariation("Belmont", "Belmotie", location, procedure);
-    testVariation("Egypt", "Egyptie", location, procedure);
-    testVariation("Claiborn", "Claiborny", location, procedure);
-    testVariation("Edelgard", "Edelgardy", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Kemp", "Kempie", location, procedure, field);
+    testVariation("Armond", "Armody", location, procedure, field);
+    testVariation("Hank", "Haky", location, procedure, field);
+    testVariation("Belmont", "Belmotie", location, procedure, field);
+    testVariation("Egypt", "Egyptie", location, procedure, field);
+    testVariation("Claiborn", "Claiborny", location, procedure, field);
+    testVariation("Edelgard", "Edelgardy", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-6.1";
     procedure = ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_ENDINGS;
+    field = Field.MOTHERS_MAIDEN_NAME;
 
-    testVariation("York", "Yorkie", location, procedure);
-    testVariation("Fisk", "Fisky", location, procedure);
-    testVariation("Chasm", "Chasmon", location, procedure);
-    testVariation("Whisp", "Whisper", location, procedure);
-    testVariation("Forrest", "Forreon", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("York", "Yorkie", location, procedure, field);
+    testVariation("Fisk", "Fisky", location, procedure, field);
+    testVariation("Chasm", "Chasmon", location, procedure, field);
+    testVariation("Whisp", "Whisper", location, procedure, field);
+    testVariation("Forrest", "Forreon", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-6.2";
     procedure = ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_ENDINGS;
+    field = Field.MOTHERS_FIRST_NAME;
 
-    testVariation("Olivia", "Oliviay", location, procedure);
-    testVariation("Emma", "Emmay", location, procedure);
-    testVariation("Charlotte", "Charlottee", location, procedure);
-    testVariation("Amelia", "Ameliay", location, procedure);
-    testVariation("Ava", "Avay", location, procedure);
-    testVariation("Sophia", "Sophiay", location, procedure);
-    testVariation("Isabella", "Isabellay", location, procedure);
-    testVariation("Mia", "Miay", location, procedure);
-    testVariation("Evelyn", "Evelymm", location, procedure);
-    testVariation("Harper", "Harperrie", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Olivia", "Oliviay", location, procedure, field);
+    testVariation("Emma", "Emmay", location, procedure, field);
+    testVariation("Charlotte", "Charlottee", location, procedure, field);
+    testVariation("Amelia", "Ameliay", location, procedure, field);
+    testVariation("Ava", "Avay", location, procedure, field);
+    testVariation("Sophia", "Sophiay", location, procedure, field);
+    testVariation("Isabella", "Isabellay", location, procedure, field);
+    testVariation("Mia", "Miay", location, procedure, field);
+    testVariation("Evelyn", "Evelymm", location, procedure, field);
+    testVariation("Harper", "Harperrie", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-11.1";
     procedure = ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_ENDINGS;
+    field = Field.ADDRESS_STREET;
 
-    testVariation("555 Crescent Ln.", "555 Crescent Lmm.", location, procedure);
-    testVariation("1000 North La Sierra Dr.", "1000 North La Sierra Drrie.", location, procedure);
-    testVariation("808 Beechwood Drive", "808 Beechwood Drivee", location, procedure);
-    testVariation("W984 Gainsway Ave", "W984 Gainsway Avee", location, procedure);
-    testVariation("N9655 Denning Road", "N9655 Denning Roadd", location, procedure);
-    testVariation("12 Glen Ridge Blvd.", "12 Glen Ridge Blvdd.", location, procedure);
-    testVariation("100a Bohemia Circ;", "100a Bohemia Cirk;", location, procedure);
-    testVariation("988112 Albany Street", "988112 Albany Streets", location, procedure);
-    testVariation("16 Abbey Rd.", "16 Abbey Rdy.", location, procedure);
-    testVariation("5 Shore Ave.", "5 Shore Avee.", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("555 Crescent Ln.", "555 Crescent Lmm.", location, procedure, field);
+    testVariation("1000 North La Sierra Dr.", "1000 North La Sierra Drrie.", location, procedure,
+        field);
+    testVariation("808 Beechwood Drive", "808 Beechwood Drivee", location, procedure, field);
+    testVariation("W984 Gainsway Ave", "W984 Gainsway Avee", location, procedure, field);
+    testVariation("N9655 Denning Road", "N9655 Denning Roadd", location, procedure, field);
+    testVariation("12 Glen Ridge Blvd.", "12 Glen Ridge Blvdd.", location, procedure, field);
+    testVariation("100a Bohemia Circ;", "100a Bohemia Cirk;", location, procedure, field);
+    testVariation("988112 Albany Street", "988112 Albany Streets", location, procedure, field);
+    testVariation("16 Abbey Rd.", "16 Abbey Rdy.", location, procedure, field);
+    testVariation("5 Shore Ave.", "5 Shore Avee.", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-11.3";
     procedure = ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_ENDINGS;
+    field = Field.ADDRESS_CITY;
 
-    testVariation("Kansas City", "Kansas Citie", location, procedure);
-    testVariation("Chandler", "Chandlerrie", location, procedure);
-    testVariation("Las Vegas", "Las Vegasz", location, procedure);
-    testVariation("Buffalo", "Buffaloo", location, procedure);
-    testVariation("Lexington-Fayette", "Lexington-Fayettee", location, procedure);
-    testVariation("Minneapolis", "Minneapolisz", location, procedure);
-    testVariation("St. Paul", "St. Pauls", location, procedure);
-    testVariation("North Hempstead", "North Hempsteadd", location, procedure);
-    testVariation("Nashville-Davidson", "Nashville-Davidsomm", location, procedure);
-    testVariation("Salt Lake City", "Salt Lake Citie", location, procedure);
-    testVariation("", "", location, procedure);
+    testVariation("Kansas City", "Kansas Citie", location, procedure, field);
+    testVariation("Chandler", "Chandlerrie", location, procedure, field);
+    testVariation("Las Vegas", "Las Vegasz", location, procedure, field);
+    testVariation("Buffalo", "Buffaloo", location, procedure, field);
+    testVariation("Lexington-Fayette", "Lexington-Fayettee", location, procedure, field);
+    testVariation("Minneapolis", "Minneapolisz", location, procedure, field);
+    testVariation("St. Paul", "St. Pauls", location, procedure, field);
+    testVariation("North Hempstead", "North Hempsteadd", location, procedure, field);
+    testVariation("Nashville-Davidson", "Nashville-Davidsomm", location, procedure, field);
+    testVariation("Salt Lake City", "Salt Lake Citie", location, procedure, field);
+    testVariation("", "", location, procedure, field);
 
     location = "PID-13.4";
     procedure = ProcedureFactory.EMAIL_ALTERNATIVE_ENDINGS;
+    field = Field.EMAIL;
 
     // random emails from randomlists.com
-    testDifferent("dwendlan@me.com", "dwendlan@me.conn", location, procedure);
-    testDifferent("lauronen@msn.com", "lauronen@msn.conn", location, procedure);
-    testDifferent("wmszeliga@gmail.com", "wmszeliga@gmail.conn", location, procedure);
-    testDifferent("isotopian@yahoo.com", "isotopian@yahoo.conn", location, procedure);
-    testDifferent("osrin@att.net", "osrin@att.nets", location, procedure);
-    testDifferent("paina@optonline.net", "paina@optonline.nets", location, procedure);
-    testDifferent("hamilton@gmail.com", "hamilton@gmail.conn", location, procedure);
-    testDifferent("gboss@mac.com", "gboss@mac.conn", location, procedure);
-    testDifferent("peoplesr@comcast.net", "peoplesr@comcast.nets", location, procedure);
-    testDifferent("lipeng@gmail.com", "lipeng@gmail.conn", location, procedure);
+    testDifferent("dwendlan@me.com", "dwendlan@me.conn", location, procedure, field);
+    testDifferent("lauronen@msn.com", "lauronen@msn.conn", location, procedure, field);
+    testDifferent("wmszeliga@gmail.com", "wmszeliga@gmail.conn", location, procedure, field);
+    testDifferent("isotopian@yahoo.com", "isotopian@yahoo.conn", location, procedure, field);
+    testDifferent("osrin@att.net", "osrin@att.nets", location, procedure, field);
+    testDifferent("paina@optonline.net", "paina@optonline.nets", location, procedure, field);
+    testDifferent("hamilton@gmail.com", "hamilton@gmail.conn", location, procedure, field);
+    testDifferent("gboss@mac.com", "gboss@mac.conn", location, procedure, field);
+    testDifferent("peoplesr@comcast.net", "peoplesr@comcast.nets", location, procedure, field);
+    testDifferent("lipeng@gmail.com", "lipeng@gmail.conn", location, procedure, field);
   }
 
-  private void testVariation(String startValue, String endValue, String location,
-      String procedure) {
-    assertEquals(endValue, AlternativeEndings.varyName(startValue));
+  private void testVariation(String startValue, String endValue, String location, String procedure,
+      Field field) {
+    assertEquals(endValue, AlternativeEndings.varyName(startValue, field));
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     String testEnd = transform(DEFAULT_TEST_MESSAGE, location + "=" + endValue);
     testEquals(testStart, testEnd, procedure);
   }
 
-  private void testDifferent(String startValue, String endValue, String location,
-      String procedure) {
-    assertEquals(endValue, AlternativeEndings.varyName(startValue));
+  private void testDifferent(String startValue, String endValue, String location, String procedure,
+      Field field) {
+    assertEquals(endValue, AlternativeEndings.varyName(startValue, field));
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     String after = processProcedureChangesMessage(testStart, procedure);
     assertNotEquals(testStart, after);

--- a/src/test/java/org/immregistries/smm/transform/procedure/AlternativeVowelsTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/AlternativeVowelsTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.immregistries.smm.tester.manager.HL7Reader;
 import org.immregistries.smm.transform.Transformer;
+import org.immregistries.smm.transform.procedure.AlternativeVowels.Field;
 import org.junit.Test;
 
 public class AlternativeVowelsTest extends ProcedureCommonTest {
@@ -13,66 +14,68 @@ public class AlternativeVowelsTest extends ProcedureCommonTest {
     Transformer transformer = new Transformer();
     // Testing multiple times to make sure random process is consistent
 
-    List<List<String>> locationProcedurePairs =
-        Arrays.asList(Arrays.asList("PID-5.1", ProcedureFactory.LAST_NAME_ALTERNATIVE_VOWELS),
-            Arrays.asList("PID-5.2", ProcedureFactory.FIRST_NAME_ALTERNATIVE_VOWELS),
-            Arrays.asList("PID-5.3", ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_VOWELS),
-            Arrays.asList("PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_VOWELS),
-            Arrays.asList("PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_VOWELS),
-            Arrays.asList("PID-11.1", ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_VOWELS),
-            Arrays.asList("PID-11.3", ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_VOWELS),
-            Arrays.asList("PID-13.4", ProcedureFactory.EMAIL_ALTERNATIVE_VOWELS));
+    List<Triplet> triplets = Arrays.asList(
+        new Triplet("PID-5.1", ProcedureFactory.LAST_NAME_ALTERNATIVE_VOWELS, Field.LAST_NAME),
+        new Triplet("PID-5.2", ProcedureFactory.FIRST_NAME_ALTERNATIVE_VOWELS, Field.FIRST_NAME),
+        new Triplet("PID-5.3", ProcedureFactory.MIDDLE_NAME_ALTERNATIVE_VOWELS, Field.MIDDLE_NAME),
+        new Triplet("PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_ALTERNATIVE_VOWELS,
+            Field.MOTHERS_MAIDEN_NAME),
+        new Triplet("PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_ALTERNATIVE_VOWELS,
+            Field.MOTHERS_FIRST_NAME),
+        new Triplet("PID-11.1", ProcedureFactory.ADDRESS_STREET_ALTERNATIVE_VOWELS,
+            Field.ADDRESS_STREET),
+        new Triplet("PID-11.3", ProcedureFactory.ADDRESS_CITY_ALTERNATIVE_VOWELS,
+            Field.ADDRESS_CITY),
+        new Triplet("PID-13.4", ProcedureFactory.EMAIL_ALTERNATIVE_VOWELS, Field.EMAIL));
 
-    for (List<String> pair : locationProcedurePairs) {
+    for (Triplet trip : triplets) {
       for (int i = 0; i < 100; i++) {
-        String location = pair.get(0);
-        String procedure = pair.get(1);
-
-        testVariationDifferent("Sammie", location, procedure, transformer);
-        testVariationDifferent("Herbert", location, procedure, transformer);
-        testVariationDifferent("Greyson", location, procedure, transformer);
-        testVariationDifferent("Emily", location, procedure, transformer);
-        testVariationDifferent("Earl", location, procedure, transformer);
-        testVariationDifferent("Bob", location, procedure, transformer);
-        testVariationDifferent("Doug", location, procedure, transformer);
-        testVariationDifferent("Kayla", location, procedure, transformer);
-        testVariationDifferent("Goose", location, procedure, transformer);
-        testVariationDifferent("Mouse", location, procedure, transformer);
-        testVariationDifferent("Chewie", location, procedure, transformer);
-        testVariationDifferent("100 Figaro Ave.", location, procedure, transformer);
-        testVariationDifferent("Bobby Lee", location, procedure, transformer);
-        testVariationDifferent("Green Bay", location, procedure, transformer);
-        testVariationDifferent("test.email@gmail.com", location, procedure, transformer);
-        testVariationDifferent("", location, procedure, transformer);
+        testVariationDifferent("Sammie", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Herbert", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Greyson", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Emily", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Earl", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Bob", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Doug", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Kayla", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Goose", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Mouse", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Chewie", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("100 Figaro Ave.", trip.location, trip.procedure, transformer,
+            trip.field);
+        testVariationDifferent("Bobby Lee", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("Green Bay", trip.location, trip.procedure, transformer, trip.field);
+        testVariationDifferent("test.email@gmail.com", trip.location, trip.procedure, transformer,
+            trip.field);
+        testVariationDifferent("", trip.location, trip.procedure, transformer, trip.field);
 
         // won't change first letter so "i" or "e" has to change
-        assertTrue(AlternativeVowels.varyName("Annie", transformer).startsWith("Ann"));
+        assertTrue(AlternativeVowels.varyName("Annie", transformer, trip.field).startsWith("Ann"));
 
         // only vowel is the first and we're not changing that
-        testVariation("Ann", "Ann", location, procedure, transformer);
+        testVariation("Ann", "Ann", trip.location, trip.procedure, transformer, trip.field);
       }
     }
   }
 
-
   private void testVariation(String startValue, String endValue, String location, String procedure,
-      Transformer transformer) {
+      Transformer transformer, Field field) {
     if (ProcedureFactory.EMAIL_ALTERNATIVE_VOWELS.equals(procedure)) {
       return;
     }
 
-    assertEquals(endValue, AlternativeVowels.varyName(startValue, transformer));
+    assertEquals(endValue, AlternativeVowels.varyName(startValue, transformer, field));
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     String testEnd = transform(DEFAULT_TEST_MESSAGE, location + "=" + endValue);
     testEquals(testStart, testEnd, procedure);
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,
-      Transformer transformer) {
+      Transformer transformer, Field field) {
     // the documentation for this procedure states a substitution is not guaranteed
     // so guaranteeing a test that passes 100% of the time is difficult without making it complex
 
-    String variation = AlternativeVowels.varyName(startValue, transformer);
+    String variation = AlternativeVowels.varyName(startValue, transformer, field);
     assertTrue(startValue.equals(variation) || variation.startsWith(startValue.substring(0, 1)));
 
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
@@ -89,4 +92,15 @@ public class AlternativeVowelsTest extends ProcedureCommonTest {
         || procedureResult.startsWith(startValue.substring(0, 1)));
   }
 
+  private class Triplet {
+    String location;
+    String procedure;
+    Field field;
+
+    Triplet(String location, String procedure, Field field) {
+      this.location = location;
+      this.procedure = procedure;
+      this.field = field;
+    }
+  }
 }

--- a/src/test/java/org/immregistries/smm/transform/procedure/HyphenateVariationTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/HyphenateVariationTest.java
@@ -40,41 +40,43 @@ public class HyphenateVariationTest extends ProcedureCommonTest {
   public void test() {
     Transformer transformer = new Transformer();
 
-    for (TestingGroup group : TestingGroup.values()) {
-      String location = group.location;
-      Field field = group.field;
-      String procedure = group.procedure;
+    for (int i = 0; i < 100; i++) {
+      for (TestingGroup group : TestingGroup.values()) {
+        String location = group.location;
+        Field field = group.field;
+        String procedure = group.procedure;
 
-      if (group == TestingGroup.EMAIL) {
-        String email = "bob@gmail.com";
-        String varied = HyphenateVariation.varyName(email, transformer, field);
-        assertTrue(varied.length() > email.length());
-        assertTrue(varied.startsWith("bob-"));
-        assertTrue(varied.endsWith("@gmail.com"));
+        if (group == TestingGroup.EMAIL) {
+          String email = "bob@gmail.com";
+          String varied = HyphenateVariation.varyName(email, transformer, field);
+          assertTrue(varied.length() > email.length());
+          assertTrue(varied.startsWith("bob-"));
+          assertTrue(varied.endsWith("@gmail.com"));
 
-        email = "bob-jones@gmail.com";
-        varied = HyphenateVariation.varyName(email, transformer, field);
-        assertTrue(varied.length() > email.length());
-        assertTrue(varied.startsWith("bob-"));
-        assertTrue(varied.endsWith("@gmail.com"));
-      } else if (group == TestingGroup.ADDRESS_STREET) {
-        String address = "123 Main St.";
-        String varied = HyphenateVariation.varyName(address, transformer, field);
-        assertTrue(varied.length() > address.length());
-        assertTrue(varied.startsWith("123 Main-"));
-        assertTrue(varied.endsWith(" St."));
-      } else {
-        testVariation("Smith-Jones", "Smith Jones", transformer, location, field, procedure);
-        testVariation("Smith Jones", "Smith-Jones", transformer, location, field, procedure);
-        testVariation("Smith-jones", "Smith Jones", transformer, location, field, procedure);
-        testVariation("smith-jones", "smith jones", transformer, location, field, procedure);
-        assertEquals("Smith-Jones", HyphenateVariation.varyName(
-            HyphenateVariation.varyName("Smith-Jones", transformer, field), transformer, field));
-        assertNotEquals("", HyphenateVariation
-            .varyName(HyphenateVariation.varyName("", transformer, field), transformer, field));
-        testVariationDifferent("Smith", transformer, location, field, procedure);
-        testVariationDifferent("JONES", transformer, location, field, procedure);
-        testVariationDifferent("carpenter", transformer, location, field, procedure);
+          email = "bob-jones@gmail.com";
+          varied = HyphenateVariation.varyName(email, transformer, field);
+          assertTrue(varied.length() > email.length());
+          assertTrue(varied.startsWith("bob-"));
+          assertTrue(varied.endsWith("@gmail.com"));
+        } else if (group == TestingGroup.ADDRESS_STREET) {
+          String address = "123 Main St.";
+          String varied = HyphenateVariation.varyName(address, transformer, field);
+          assertTrue(varied.length() > address.length());
+          assertTrue(varied.startsWith("123 Main-"));
+          assertTrue(varied.endsWith(" St."));
+        } else {
+          testVariation("Smith-Jones", "Smith Jones", transformer, location, field, procedure);
+          testVariation("Smith Jones", "Smith-Jones", transformer, location, field, procedure);
+          testVariation("Smith-jones", "Smith Jones", transformer, location, field, procedure);
+          testVariation("smith-jones", "smith jones", transformer, location, field, procedure);
+          assertEquals("Smith-Jones", HyphenateVariation.varyName(
+              HyphenateVariation.varyName("Smith-Jones", transformer, field), transformer, field));
+          assertNotEquals("", HyphenateVariation
+              .varyName(HyphenateVariation.varyName("", transformer, field), transformer, field));
+          testVariationDifferent("Smith", transformer, location, field, procedure);
+          testVariationDifferent("JONES", transformer, location, field, procedure);
+          testVariationDifferent("carpenter", transformer, location, field, procedure);
+        }
       }
     }
   }

--- a/src/test/java/org/immregistries/smm/transform/procedure/ProcedureCommonTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/ProcedureCommonTest.java
@@ -51,7 +51,8 @@ public class ProcedureCommonTest extends TestCase {
 
   protected void testProcedureChangesMessageAndDoesNotContain(String om, String fieldText,
       String procedure) {
-    assertEquals(-1, testProcedureChangesMessage(om, procedure).indexOf(fieldText));
+    String changed = testProcedureChangesMessage(om, procedure);
+    assertEquals("Found '" + fieldText + "' in '" + changed + "'", -1, changed.indexOf(fieldText));
   }
 
   protected void testProcedureChangesMessageAndDoesContain(String om, String fieldText,
@@ -97,5 +98,64 @@ public class ProcedureCommonTest extends TestCase {
     assertEquals("", ProcedureCommon.readRepeatValue("^NET^^email@email.com^", 5));
     assertEquals("", ProcedureCommon.readRepeatValue("^NET^^email@email.com", 5));
     assertEquals("", ProcedureCommon.readRepeatValue("^NET^^email@email.com", 7));
+  }
+
+  @Test
+  public void testMakeEmailValid() {
+    assertEquals("", ProcedureCommon.makeEmailValid(null));
+    assertEquals("", ProcedureCommon.makeEmailValid(""));
+    assertEquals("", ProcedureCommon.makeEmailValid(" "));
+    assertEquals("", ProcedureCommon.makeEmailValid("\t"));
+    assertEquals("", ProcedureCommon.makeEmailValid("\r\n"));
+    assertEquals("", ProcedureCommon.makeEmailValid("\n"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bob vance@gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bob  vance@gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bob   vance@gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bob    vance@gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bob\tvance@gmail.com"));
+    assertEquals("address@newberlin.com",
+        ProcedureCommon.makeEmailValid("address@new\r\nberlin.com"));
+    assertEquals("address@newberlin.com",
+        ProcedureCommon.makeEmailValid("address@new\nberlin.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid(".bobvance@gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance.@gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid(".bobvance.@gmail.com"));
+    assertEquals("bob.vance@gmail.com", ProcedureCommon.makeEmailValid(".bob.vance.@gmail.com"));
+    assertEquals("bob.vance@gmail.com",
+        ProcedureCommon.makeEmailValid("...bob.vance.....@gmail.com"));
+    assertEquals("bob.vance@gmail.com", ProcedureCommon.makeEmailValid("bob..vance@gmail.com"));
+    assertEquals("bob.vance@gmail.com", ProcedureCommon.makeEmailValid("bob...vance@gmail.com"));
+    assertEquals("bob.v.ance@gmail.com",
+        ProcedureCommon.makeEmailValid("bob....v......ance@gmail.com"));
+    assertEquals("1234567890123456789012345678901234567890123456789012345678901234@gmail.com",
+        ProcedureCommon.makeEmailValid(
+            "1234567890123456789012345678901234567890123456789012345678901234567890@gmail.com"));
+    assertEquals("1234567890123456789012345678901234567890123456789012345678901234@gmail.com",
+        ProcedureCommon.makeEmailValid(
+            "1234567890123456789012345678901234567890123456789012345678901234@gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@.gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@gmail.com."));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@.gmail.com."));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@..gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@gmail.com.."));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@..gmail.com.."));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@....gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@gmail.com...."));
+    assertEquals("bobvance@gmail.com",
+        ProcedureCommon.makeEmailValid("bobvance@....gmail.com...."));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@-gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@gmail.com-"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@-gmail.com-"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@--gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@gmail.com--"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@--gmail.com--"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@----gmail.com"));
+    assertEquals("bobvance@gmail.com", ProcedureCommon.makeEmailValid("bobvance@gmail.com----"));
+    assertEquals("bobvance@gmail.com",
+        ProcedureCommon.makeEmailValid("bobvance@----gmail.com----"));
+    assertEquals("bobvance@gmail.com",
+        ProcedureCommon.makeEmailValid("bobvance@....gmail.....com...."));
   }
 }

--- a/src/test/java/org/immregistries/smm/transform/procedure/RepeatedConsonantsTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/RepeatedConsonantsTest.java
@@ -2,6 +2,7 @@ package org.immregistries.smm.transform.procedure;
 
 import static org.junit.Assert.assertNotEquals;
 import org.immregistries.smm.transform.Transformer;
+import org.immregistries.smm.transform.procedure.RepeatedConsonants.Field;
 import org.junit.Test;
 
 public class RepeatedConsonantsTest extends ProcedureCommonTest {
@@ -10,91 +11,103 @@ public class RepeatedConsonantsTest extends ProcedureCommonTest {
   @Test
   public void test() {
     Transformer transformer = new Transformer();
-    String location = "PID-5.1";
-    String procedure = ProcedureFactory.LAST_NAME_REPEATED_CONSONANTS;
 
-    testVariationDifferent("Sanchez", location, procedure, transformer);
-    testVariationDifferent("Yates", location, procedure, transformer);
-    testVariationDifferent("Wiggins", location, procedure, transformer);
-    testVariationDifferent("Vasquez", location, procedure, transformer);
-    testVariationDifferent("Lambert", location, procedure, transformer);
-    testVariationDifferent("Daugherty", location, procedure, transformer);
+    for (int i = 0; i < 100; i++) {
+      String location = "PID-5.1";
+      String procedure = ProcedureFactory.LAST_NAME_REPEATED_CONSONANTS;
+      Field field = Field.LAST_NAME;
 
-    location = "PID-5.2";
-    procedure = ProcedureFactory.FIRST_NAME_REPEATED_CONSONANTS;
+      testVariationDifferent("Sanchez", location, procedure, transformer, field);
+      testVariationDifferent("Yates", location, procedure, transformer, field);
+      testVariationDifferent("Wiggins", location, procedure, transformer, field);
+      testVariationDifferent("Vasquez", location, procedure, transformer, field);
+      testVariationDifferent("Lambert", location, procedure, transformer, field);
+      testVariationDifferent("Daugherty", location, procedure, transformer, field);
 
-    testVariationDifferent("Sammie", location, procedure, transformer);
-    testVariationDifferent("Sam", location, procedure, transformer);
-    testVariationDifferent("Kalyn", location, procedure, transformer);
-    testVariationDifferent("Howard", location, procedure, transformer);
-    testVariationDifferent("Heather", location, procedure, transformer);
-    testVariationDifferent("Ivan", location, procedure, transformer);
+      location = "PID-5.2";
+      procedure = ProcedureFactory.FIRST_NAME_REPEATED_CONSONANTS;
+      field = Field.FIRST_NAME;
 
-    location = "PID-5.3";
-    procedure = ProcedureFactory.MIDDLE_NAME_REPEATED_CONSONANTS;
+      testVariationDifferent("Sammie", location, procedure, transformer, field);
+      testVariationDifferent("Sam", location, procedure, transformer, field);
+      testVariationDifferent("Kalyn", location, procedure, transformer, field);
+      testVariationDifferent("Howard", location, procedure, transformer, field);
+      testVariationDifferent("Heather", location, procedure, transformer, field);
+      testVariationDifferent("Ivan", location, procedure, transformer, field);
 
-    testVariationDifferent("Bradley", location, procedure, transformer);
-    testVariationDifferent("Blankenship", location, procedure, transformer);
-    testVariationDifferent("Mccarty", location, procedure, transformer);
-    testVariationDifferent("Barrett", location, procedure, transformer);
-    testVariationDifferent("Matthews", location, procedure, transformer);
-    testVariationDifferent("Wyatt", location, procedure, transformer);
+      location = "PID-5.3";
+      procedure = ProcedureFactory.MIDDLE_NAME_REPEATED_CONSONANTS;
+      field = Field.MIDDLE_NAME;
 
-    location = "PID-6.1";
-    procedure = ProcedureFactory.MOTHERS_MAIDEN_NAME_REPEATED_CONSONANTS;
+      testVariationDifferent("Bradley", location, procedure, transformer, field);
+      testVariationDifferent("Blankenship", location, procedure, transformer, field);
+      testVariationDifferent("Mccarty", location, procedure, transformer, field);
+      testVariationDifferent("Barrett", location, procedure, transformer, field);
+      testVariationDifferent("Matthews", location, procedure, transformer, field);
+      testVariationDifferent("Wyatt", location, procedure, transformer, field);
 
-    testVariationDifferent("Simmons", location, procedure, transformer);
-    testVariationDifferent("Rasmussen", location, procedure, transformer);
-    testVariationDifferent("Blanchard", location, procedure, transformer);
-    testVariationDifferent("Chandler", location, procedure, transformer);
-    testVariationDifferent("Carpenter", location, procedure, transformer);
-    testVariationDifferent("Pitts", location, procedure, transformer);
+      location = "PID-6.1";
+      procedure = ProcedureFactory.MOTHERS_MAIDEN_NAME_REPEATED_CONSONANTS;
+      field = Field.MOTHERS_MAIDEN_NAME;
 
-    location = "PID-6.2";
-    procedure = ProcedureFactory.MOTHERS_FIRST_NAME_REPEATED_CONSONANTS;
+      testVariationDifferent("Simmons", location, procedure, transformer, field);
+      testVariationDifferent("Rasmussen", location, procedure, transformer, field);
+      testVariationDifferent("Blanchard", location, procedure, transformer, field);
+      testVariationDifferent("Chandler", location, procedure, transformer, field);
+      testVariationDifferent("Carpenter", location, procedure, transformer, field);
+      testVariationDifferent("Pitts", location, procedure, transformer, field);
 
-    testVariationDifferent("Daisy", location, procedure, transformer);
-    testVariationDifferent("Mary", location, procedure, transformer);
-    testVariationDifferent("Gail", location, procedure, transformer);
-    testVariationDifferent("Debra", location, procedure, transformer);
-    testVariationDifferent("Missy", location, procedure, transformer);
-    testVariationDifferent("Joan", location, procedure, transformer);
+      location = "PID-6.2";
+      procedure = ProcedureFactory.MOTHERS_FIRST_NAME_REPEATED_CONSONANTS;
+      field = Field.MOTHERS_FIRST_NAME;
 
-    location = "PID-11.1";
-    procedure = ProcedureFactory.ADDRESS_STREET_REPEATED_CONSONANTS;
+      testVariationDifferent("Daisy", location, procedure, transformer, field);
+      testVariationDifferent("Mary", location, procedure, transformer, field);
+      testVariationDifferent("Gail", location, procedure, transformer, field);
+      testVariationDifferent("Debra", location, procedure, transformer, field);
+      testVariationDifferent("Missy", location, procedure, transformer, field);
+      testVariationDifferent("Joan", location, procedure, transformer, field);
 
-    testVariationDifferent("1001 Howard Drive.", location, procedure, transformer);
-    testVariationDifferent("1600 Pennsylvania Avenue", location, procedure, transformer);
-    testVariationDifferent("1000 North La Sierra Dr.", location, procedure, transformer);
-    testVariationDifferent("W984 Gainsway Ave", location, procedure, transformer);
-    testVariationDifferent("100a Bohemia Circ.", location, procedure, transformer);
-    testVariationDifferent("N9655 Denning Road", location, procedure, transformer);
+      location = "PID-11.1";
+      procedure = ProcedureFactory.ADDRESS_STREET_REPEATED_CONSONANTS;
+      field = Field.ADDRESS_STREET;
 
-    location = "PID-11.3";
-    procedure = ProcedureFactory.ADDRESS_CITY_REPEATED_CONSONANTS;
+      testVariationDifferent("1001 Howard Drive.", location, procedure, transformer, field);
+      testVariationDifferent("1600 Pennsylvania Avenue", location, procedure, transformer, field);
+      testVariationDifferent("1000 North La Sierra Dr.", location, procedure, transformer, field);
+      testVariationDifferent("W984 Gainsway Ave", location, procedure, transformer, field);
+      testVariationDifferent("100a Bohemia Circ.", location, procedure, transformer, field);
+      testVariationDifferent("N9655 Denning Road", location, procedure, transformer, field);
 
-    testVariationDifferent("Kansas City", location, procedure, transformer);
-    testVariationDifferent("Lexington-Fayette", location, procedure, transformer);
-    testVariationDifferent("St. Paul", location, procedure, transformer);
-    testVariationDifferent("Salt Lake City", location, procedure, transformer);
-    testVariationDifferent("Chandler", location, procedure, transformer);
-    testVariationDifferent("North Hempstead", location, procedure, transformer);
+      location = "PID-11.3";
+      procedure = ProcedureFactory.ADDRESS_CITY_REPEATED_CONSONANTS;
+      field = Field.ADDRESS_CITY;
 
-    location = "PID-13.4";
-    procedure = ProcedureFactory.EMAIL_REPEATED_CONSONANTS;
+      testVariationDifferent("Kansas City", location, procedure, transformer, field);
+      testVariationDifferent("Lexington-Fayette", location, procedure, transformer, field);
+      testVariationDifferent("St. Paul", location, procedure, transformer, field);
+      testVariationDifferent("Salt Lake City", location, procedure, transformer, field);
+      testVariationDifferent("Chandler", location, procedure, transformer, field);
+      testVariationDifferent("North Hempstead", location, procedure, transformer, field);
 
-    // random emails from randomlists.com
-    testVariationDifferent("dwendlan@me.com", location, procedure, transformer);
-    testVariationDifferent("lauronen@msn.com", location, procedure, transformer);
-    testVariationDifferent("wmszeliga@gmail.com", location, procedure, transformer);
-    testVariationDifferent("isotopian@yahoo.com", location, procedure, transformer);
-    testVariationDifferent("osrin@att.net", location, procedure, transformer);
-    testVariationDifferent("lipeng@gmail.com", location, procedure, transformer);
+      location = "PID-13.4";
+      procedure = ProcedureFactory.EMAIL_REPEATED_CONSONANTS;
+      field = Field.EMAIL;
+
+      // random emails from randomlists.com
+      testVariationDifferent("dwendlan@me.com", location, procedure, transformer, field);
+      testVariationDifferent("lauronen@msn.com", location, procedure, transformer, field);
+      testVariationDifferent("wmszeliga@gmail.com", location, procedure, transformer, field);
+      testVariationDifferent("isotopian@yahoo.com", location, procedure, transformer, field);
+      testVariationDifferent("osrin@att.net", location, procedure, transformer, field);
+      testVariationDifferent("lipeng@gmail.com", location, procedure, transformer, field);
+    }
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,
-      Transformer transformer) {
-    assertNotEquals(startValue, RepeatedConsonants.varyName(startValue, transformer));
+      Transformer transformer, Field field) {
+    String endValue = RepeatedConsonants.varyName(startValue, transformer, field);
+    assertNotEquals("start = '" + startValue + "' to " + endValue + "'", startValue, endValue);
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     testProcedureChangesMessage(testStart, procedure);
   }

--- a/src/test/java/org/immregistries/smm/transform/procedure/SpecialCharactersExtendedTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/SpecialCharactersExtendedTest.java
@@ -10,76 +10,78 @@ public class SpecialCharactersExtendedTest extends ProcedureCommonTest {
   public void test() {
     Transformer transformer = new Transformer();
 
-    testVariationDifferent("CARPENTER", "PID-5.1",
-        ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Washington", "PID-5.1",
-        ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Hyphen-nated", "PID-5.1",
-        ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Twolast Names", "PID-5.1",
-        ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+    for (int i = 0; i < 100; i++) {
+      testVariationDifferent("CARPENTER", "PID-5.1",
+          ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Washington", "PID-5.1",
+          ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Hyphen-nated", "PID-5.1",
+          ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Twolast Names", "PID-5.1",
+          ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
 
-    SpecialCharactersExtended sc = new SpecialCharactersExtended(null);
-    sc.setTransformer(transformer);
-    assertEquals("Off", sc.varyText("Off"));
-    assertEquals("Em", sc.varyText("Em"));
-    assertEquals("O" + (char) 0xF1, sc.varyText("On"));
-    assertEquals("", sc.varyText(""));
+      SpecialCharactersExtended sc = new SpecialCharactersExtended(null);
+      sc.setTransformer(transformer);
+      assertEquals("Off", sc.varyText("Off"));
+      assertEquals("Em", sc.varyText("Em"));
+      assertEquals("O" + (char) 0xF1, sc.varyText("On"));
+      assertEquals("", sc.varyText(""));
 
-    testVariationDifferent("Samuel", "PID-5.2",
-        ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Emily", "PID-5.2",
-        ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Mary Sue", "PID-5.2",
-        ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Ye Sune", "PID-5.2",
-        ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Samuel", "PID-5.2",
+          ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Emily", "PID-5.2",
+          ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Mary Sue", "PID-5.2",
+          ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Ye Sune", "PID-5.2",
+          ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
 
-    testVariationDifferent("Jennifer", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Ryan", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Frederick Dempsey", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Stan", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Jennifer", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Ryan", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Frederick Dempsey", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Stan", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
 
-    testVariationDifferent("Grace", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Patrick", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Ziegfried", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Threepwood", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Grace", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Patrick", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Ziegfried", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Threepwood", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
 
-    testVariationDifferent("Sandra", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Emily", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Mary Sue", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Ye Sune", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Sandra", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Emily", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Mary Sue", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Ye Sune", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS_EXTENDED, transformer);
 
-    testVariationDifferent("something@gmail.com", "PID-13.4",
-        ProcedureFactory.EMAIL_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("plus+sign@apple.net", "PID-13.4",
-        ProcedureFactory.EMAIL_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("something@gmail.com", "PID-13.4",
+          ProcedureFactory.EMAIL_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("plus+sign@apple.net", "PID-13.4",
+          ProcedureFactory.EMAIL_SPECIAL_CHARACTERS_EXTENDED, transformer);
 
-    testVariationDifferent("5678 Wooster Ln", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("1234 Howard Drive", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("600 Denter St.", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("5678 Wooster Ln", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("1234 Howard Drive", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("600 Denter St.", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS_EXTENDED, transformer);
 
-    testVariationDifferent("Madison", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("New York City", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS_EXTENDED, transformer);
-    testVariationDifferent("Martha's Vineyard", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Madison", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("New York City", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS_EXTENDED, transformer);
+      testVariationDifferent("Martha's Vineyard", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS_EXTENDED, transformer);
+    }
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,

--- a/src/test/java/org/immregistries/smm/transform/procedure/SpecialCharactersTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/SpecialCharactersTest.java
@@ -10,95 +10,97 @@ public class SpecialCharactersTest extends ProcedureCommonTest {
   public void test() {
     Transformer transformer = new Transformer();
 
-    testVariationDifferent("CARPENTER", "PID-5.1", ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS,
-        transformer);
-    testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS,
-        transformer);
-    testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS,
-        transformer);
-    testVariationDifferent("Twolast Names", "PID-5.1",
-        ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS, transformer);
+    for (int i = 0; i < 100; i++) {
+      testVariationDifferent("CARPENTER", "PID-5.1", ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS,
+          transformer);
+      testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS,
+          transformer);
+      testVariationDifferent("Hyphen-nated", "PID-5.1",
+          ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Twolast Names", "PID-5.1",
+          ProcedureFactory.LAST_NAME_SPECIAL_CHARACTERS, transformer);
 
-    SpecialCharacters sc = new SpecialCharacters(null);
-    sc.setTransformer(transformer);
-    assertEquals("Odd", sc.varyText("Odd"));
-    assertEquals("Ed", sc.varyText("Ed"));
+      SpecialCharacters sc = new SpecialCharacters(null);
+      sc.setTransformer(transformer);
+      assertEquals("Odd", sc.varyText("Odd"));
+      assertEquals("Ed", sc.varyText("Ed"));
 
-    assertEquals("O" + (char) 0xF1, sc.varyText("On"));
-    assertEquals("T" + (char) 0xE1 + "d", sc.varyText("Tad"));
-    assertEquals("T" + (char) 0xE9 + "d", sc.varyText("Ted"));
-    assertEquals("P" + (char) 0xED + "t", sc.varyText("Pit"));
-    assertEquals("R" + (char) 0xF3 + "d", sc.varyText("Rod"));
-    assertEquals("", sc.varyText(""));
+      assertEquals("O" + (char) 0xF1, sc.varyText("On"));
+      assertEquals("T" + (char) 0xE1 + "d", sc.varyText("Tad"));
+      assertEquals("T" + (char) 0xE9 + "d", sc.varyText("Ted"));
+      assertEquals("P" + (char) 0xED + "t", sc.varyText("Pit"));
+      assertEquals("R" + (char) 0xF3 + "d", sc.varyText("Rod"));
+      assertEquals("", sc.varyText(""));
 
-    String lower = sc.varyText("Tug");
-    assertTrue(lower,
-        ("T" + (char) 0xFA + "g").equals(lower) || ("T" + (char) 0xFC + "g").equals(lower));
+      String lower = sc.varyText("Tug");
+      assertTrue(lower,
+          ("T" + (char) 0xFA + "g").equals(lower) || ("T" + (char) 0xFC + "g").equals(lower));
 
-    assertEquals("O" + (char) 0xD1, sc.varyText("ON"));
-    assertEquals("T" + (char) 0xC1 + "D", sc.varyText("TAD"));
-    assertEquals("T" + (char) 0xC9 + "D", sc.varyText("TED"));
-    assertEquals("P" + (char) 0xCD + "T", sc.varyText("PIT"));
-    assertEquals("R" + (char) 0xD3 + "D", sc.varyText("ROD"));
+      assertEquals("O" + (char) 0xD1, sc.varyText("ON"));
+      assertEquals("T" + (char) 0xC1 + "D", sc.varyText("TAD"));
+      assertEquals("T" + (char) 0xC9 + "D", sc.varyText("TED"));
+      assertEquals("P" + (char) 0xCD + "T", sc.varyText("PIT"));
+      assertEquals("R" + (char) 0xD3 + "D", sc.varyText("ROD"));
 
-    String upper = sc.varyText("TUG");
-    assertTrue(upper,
-        ("T" + (char) 0xDA + "G").equals(upper) || ("T" + (char) 0xDC + "G").equals(upper));
+      String upper = sc.varyText("TUG");
+      assertTrue(upper,
+          ("T" + (char) 0xDA + "G").equals(upper) || ("T" + (char) 0xDC + "G").equals(upper));
 
-    testVariationDifferent("Samuel", "PID-5.2", ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS,
-        transformer);
-    testVariationDifferent("Emily", "PID-5.2", ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS,
-        transformer);
-    testVariationDifferent("Mary Sue", "PID-5.2", ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS,
-        transformer);
-    testVariationDifferent("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS,
-        transformer);
+      testVariationDifferent("Samuel", "PID-5.2", ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS,
+          transformer);
+      testVariationDifferent("Emily", "PID-5.2", ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS,
+          transformer);
+      testVariationDifferent("Mary Sue", "PID-5.2", ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS,
+          transformer);
+      testVariationDifferent("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_SPECIAL_CHARACTERS,
+          transformer);
 
-    testVariationDifferent("Jennifer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS,
-        transformer);
-    testVariationDifferent("Ryan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS,
-        transformer);
-    testVariationDifferent("Frederick Dempsey", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS,
-        transformer);
+      testVariationDifferent("Jennifer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS,
+          transformer);
+      testVariationDifferent("Ryan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS,
+          transformer);
+      testVariationDifferent("Frederick Dempsey", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_SPECIAL_CHARACTERS,
+          transformer);
 
-    testVariationDifferent("Grace", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("Patrick", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("Ziegfried", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("Threepwood", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Grace", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Patrick", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Ziegfried", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Threepwood", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_SPECIAL_CHARACTERS, transformer);
 
-    testVariationDifferent("Sandra", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("Emily", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("Mary Sue", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("Ye Sune", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Sandra", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Emily", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Mary Sue", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Ye Sune", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_SPECIAL_CHARACTERS, transformer);
 
-    testVariationDifferent("something@gmail.com", "PID-13.4",
-        ProcedureFactory.EMAIL_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("plus+sign@apple.net", "PID-13.4",
-        ProcedureFactory.EMAIL_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("something@gmail.com", "PID-13.4",
+          ProcedureFactory.EMAIL_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("plus+sign@apple.net", "PID-13.4",
+          ProcedureFactory.EMAIL_SPECIAL_CHARACTERS, transformer);
 
-    testVariationDifferent("5678 Wooster Ln", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("1234 Howard Drive", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("600 Denter St.", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("5678 Wooster Ln", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("1234 Howard Drive", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("600 Denter St.", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_SPECIAL_CHARACTERS, transformer);
 
-    testVariationDifferent("Madison", "PID-11.3", ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS,
-        transformer);
-    testVariationDifferent("New York City", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS, transformer);
-    testVariationDifferent("Martha's Vineyard", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Madison", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("New York City", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS, transformer);
+      testVariationDifferent("Martha's Vineyard", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_SPECIAL_CHARACTERS, transformer);
+    }
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,

--- a/src/test/java/org/immregistries/smm/transform/procedure/TextChangeTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/TextChangeTest.java
@@ -11,60 +11,62 @@ public class TextChangeTest extends ProcedureCommonTest {
   public void test() {
     Transformer transformer = new Transformer();
 
-    testVariationDifferent("Robert", "PID-5.2", ProcedureFactory.FIRST_NAME_CHANGE,
-        TextChange.Field.FIRST_NAME, transformer);
-    testVariationDifferent("Betty", "PID-5.2", ProcedureFactory.FIRST_NAME_CHANGE,
-        TextChange.Field.FIRST_NAME, transformer);
-    testVariationDifferent("Sandra Dee", "PID-5.2", ProcedureFactory.FIRST_NAME_CHANGE,
-        TextChange.Field.FIRST_NAME, transformer);
+    for (int i = 0; i < 100; i++) {
+      testVariationDifferent("Robbie", "PID-5.2", ProcedureFactory.FIRST_NAME_CHANGE,
+          TextChange.Field.FIRST_NAME, transformer);
+      testVariationDifferent("Betty", "PID-5.2", ProcedureFactory.FIRST_NAME_CHANGE,
+          TextChange.Field.FIRST_NAME, transformer);
+      testVariationDifferent("Sandra Dee", "PID-5.2", ProcedureFactory.FIRST_NAME_CHANGE,
+          TextChange.Field.FIRST_NAME, transformer);
 
-    testVariationDifferent("Billy", "PID-5.3", ProcedureFactory.MIDDLE_NAME_CHANGE,
-        TextChange.Field.MIDDLE_NAME, transformer);
-    testVariationDifferent("Susan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_CHANGE,
-        TextChange.Field.MIDDLE_NAME, transformer);
-    testVariationDifferent("Hyphen-nated", "PID-5.3", ProcedureFactory.MIDDLE_NAME_CHANGE,
-        TextChange.Field.MIDDLE_NAME, transformer);
+      testVariationDifferent("Billy", "PID-5.3", ProcedureFactory.MIDDLE_NAME_CHANGE,
+          TextChange.Field.MIDDLE_NAME, transformer);
+      testVariationDifferent("Suzie", "PID-5.3", ProcedureFactory.MIDDLE_NAME_CHANGE,
+          TextChange.Field.MIDDLE_NAME, transformer);
+      testVariationDifferent("Hyphen-nated", "PID-5.3", ProcedureFactory.MIDDLE_NAME_CHANGE,
+          TextChange.Field.MIDDLE_NAME, transformer);
 
-    testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_CHANGE,
-        TextChange.Field.LAST_NAME, transformer);
-    testVariationDifferent("Black", "PID-5.1", ProcedureFactory.LAST_NAME_CHANGE,
-        TextChange.Field.LAST_NAME, transformer);
-    testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_CHANGE,
-        TextChange.Field.LAST_NAME, transformer);
+      testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_CHANGE,
+          TextChange.Field.LAST_NAME, transformer);
+      testVariationDifferent("Blacke", "PID-5.1", ProcedureFactory.LAST_NAME_CHANGE,
+          TextChange.Field.LAST_NAME, transformer);
+      testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_CHANGE,
+          TextChange.Field.LAST_NAME, transformer);
 
-    testVariationDifferent("Keller", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_CHANGE,
-        TextChange.Field.MOTHERS_MAIDEN_NAME, transformer);
-    testVariationDifferent("Scheer", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_CHANGE,
-        TextChange.Field.MOTHERS_MAIDEN_NAME, transformer);
-    testVariationDifferent("Raphael", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_CHANGE,
-        TextChange.Field.MOTHERS_MAIDEN_NAME, transformer);
+      testVariationDifferent("Keller", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_CHANGE,
+          TextChange.Field.MOTHERS_MAIDEN_NAME, transformer);
+      testVariationDifferent("Scheer", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_CHANGE,
+          TextChange.Field.MOTHERS_MAIDEN_NAME, transformer);
+      testVariationDifferent("Raphael", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_CHANGE,
+          TextChange.Field.MOTHERS_MAIDEN_NAME, transformer);
 
-    testVariationDifferent("Zabelle", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_CHANGE,
-        TextChange.Field.MOTHERS_FIRST_NAME, transformer);
-    testVariationDifferent("Lucille", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_CHANGE,
-        TextChange.Field.MOTHERS_FIRST_NAME, transformer);
-    testVariationDifferent("Martha", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_CHANGE,
-        TextChange.Field.MOTHERS_FIRST_NAME, transformer);
+      testVariationDifferent("Zabelle", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_CHANGE,
+          TextChange.Field.MOTHERS_FIRST_NAME, transformer);
+      testVariationDifferent("Lucille", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_CHANGE,
+          TextChange.Field.MOTHERS_FIRST_NAME, transformer);
+      testVariationDifferent("Martha", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_CHANGE,
+          TextChange.Field.MOTHERS_FIRST_NAME, transformer);
 
-    testVariationDifferent("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_CHANGE,
-        TextChange.Field.ADDRESS_CITY, transformer);
-    testVariationDifferent("Madison", "PID-11.3", ProcedureFactory.ADDRESS_CITY_CHANGE,
-        TextChange.Field.ADDRESS_CITY, transformer);
-    testVariationDifferent("Seattle", "PID-11.3", ProcedureFactory.ADDRESS_CITY_CHANGE,
-        TextChange.Field.ADDRESS_CITY, transformer);
+      testVariationDifferent("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_CHANGE,
+          TextChange.Field.ADDRESS_CITY, transformer);
+      testVariationDifferent("Oshkosh", "PID-11.3", ProcedureFactory.ADDRESS_CITY_CHANGE,
+          TextChange.Field.ADDRESS_CITY, transformer);
+      testVariationDifferent("Seattle", "PID-11.3", ProcedureFactory.ADDRESS_CITY_CHANGE,
+          TextChange.Field.ADDRESS_CITY, transformer);
 
-    testVariationDifferent("4356180", "PID-13.7", ProcedureFactory.PHONE_CHANGE,
-        TextChange.Field.PHONE, transformer);
-    testVariationDifferent("something@gmail.com", "PID-13#2.7", ProcedureFactory.EMAIL_CHANGE,
-        TextChange.Field.EMAIL, transformer);
+      testVariationDifferent("4356180", "PID-13.7", ProcedureFactory.PHONE_CHANGE,
+          TextChange.Field.PHONE, transformer);
 
+      testVariationDifferent("something@gmail.com", "PID-13#2.7", ProcedureFactory.EMAIL_CHANGE,
+          TextChange.Field.EMAIL, transformer);
+    }
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,
       TextChange.Field field, Transformer transformer) {
-    assertNotEquals(startValue, TextChange.varyText(startValue, field, transformer));
+    String output = TextChange.varyText(startValue, field, transformer);
+    assertNotEquals(startValue, output);
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     testProcedureChangesMessageAndDoesNotContain(testStart, startValue, procedure);
   }
-
 }

--- a/src/test/java/org/immregistries/smm/transform/procedure/TextLetterToNumberTypoTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/TextLetterToNumberTypoTest.java
@@ -13,99 +13,105 @@ public class TextLetterToNumberTypoTest extends ProcedureCommonTest {
   public void test() {
     Transformer transformer = new Transformer();
 
-    assertEquals("A", new TextLetterToNumberTypo(null).varyText("A", transformer));
-    assertEquals("a", new TextLetterToNumberTypo(null).varyText("a", transformer));
+    for (int i = 0; i < 100; i++) {
+      assertEquals("A", new TextLetterToNumberTypo(null).varyText("A", transformer));
+      assertEquals("a", new TextLetterToNumberTypo(null).varyText("a", transformer));
 
-    assertEquals("O3", new TextLetterToNumberTypo(null).varyText("Ox", transformer));
-    assertEquals("d4", new TextLetterToNumberTypo(null).varyText("da", transformer));
-    assertEquals("E0", new TextLetterToNumberTypo(null).varyText("ED", transformer));
+      assertEquals("O3", new TextLetterToNumberTypo(null).varyText("Ox", transformer));
+      assertEquals("d4", new TextLetterToNumberTypo(null).varyText("da", transformer));
+      assertEquals("E0", new TextLetterToNumberTypo(null).varyText("ED", transformer));
 
-    assertEquals("", new TextLetterToNumberTypo(null).varyText("", transformer));
+      assertEquals("", new TextLetterToNumberTypo(null).varyText("", transformer));
 
-    testVariationDifferent("CARPENTER", "PID-5.1", ProcedureFactory.LAST_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testVariationDifferent("Twolast Names", "PID-5.1", ProcedureFactory.LAST_NAME_LETTER_TO_NUMBER,
-        transformer);
+      testVariationDifferent("CARPENTER", "PID-5.1", ProcedureFactory.LAST_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testVariationDifferent("Twolast Names", "PID-5.1",
+          ProcedureFactory.LAST_NAME_LETTER_TO_NUMBER, transformer);
 
-    testVariationDifferent("Samuel", "PID-5.2", ProcedureFactory.FIRST_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testVariationDifferent("Emily", "PID-5.2", ProcedureFactory.FIRST_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testVariationDifferent("Mary Sue", "PID-5.2", ProcedureFactory.FIRST_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testVariationDifferent("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_LETTER_TO_NUMBER,
-        transformer);
+      testVariationDifferent("Samuel", "PID-5.2", ProcedureFactory.FIRST_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testVariationDifferent("Emily", "PID-5.2", ProcedureFactory.FIRST_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testVariationDifferent("Mary Sue", "PID-5.2", ProcedureFactory.FIRST_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testVariationDifferent("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_LETTER_TO_NUMBER,
+          transformer);
 
-    testVariationDifferent("Jennifer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testVariationDifferent("Ryan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testVariationDifferent("Frederick Dempsey", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_LETTER_TO_NUMBER,
-        transformer);
+      testVariationDifferent("Jennifer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testVariationDifferent("Ryan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testVariationDifferent("Frederick Dempsey", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_LETTER_TO_NUMBER,
+          transformer);
 
-    testVariationDifferent("Grace", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("Patrick", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("Ziegfried", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("Threepwood", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Grace", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Patrick", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Ziegfried", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Threepwood", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_LETTER_TO_NUMBER, transformer);
 
-    testVariationDifferent("Sandra", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("Emily", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testVariationDifferent("Mary Sue", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("Ye Sune", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Sandra", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Emily", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Mary Sue", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Ye Sune", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_LETTER_TO_NUMBER, transformer);
 
-    testVariationSame("4356180", "PID-13.7", ProcedureFactory.PHONE_LETTER_TO_NUMBER, transformer);
-    testVariationSame("1234567", "PID-13.7", ProcedureFactory.PHONE_LETTER_TO_NUMBER, transformer);
-    testVariationSame("555-5555", "PID-13.7", ProcedureFactory.PHONE_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("555-5555 ext. 555", "PID-13.7", ProcedureFactory.PHONE_LETTER_TO_NUMBER,
-        transformer);
+      testVariationSame("4356180", "PID-13.7", ProcedureFactory.PHONE_LETTER_TO_NUMBER,
+          transformer);
+      testVariationSame("1234567", "PID-13.7", ProcedureFactory.PHONE_LETTER_TO_NUMBER,
+          transformer);
+      testVariationSame("555-5555", "PID-13.7", ProcedureFactory.PHONE_LETTER_TO_NUMBER,
+          transformer);
+      testVariationDifferent("555-5555 ext. 555", "PID-13.7",
+          ProcedureFactory.PHONE_LETTER_TO_NUMBER, transformer);
 
-    testVariationDifferent("something@gmail.com", "PID-13.4",
-        ProcedureFactory.EMAIL_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("plus+sign@apple.net", "PID-13.4",
-        ProcedureFactory.EMAIL_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("something@gmail.com", "PID-13.4",
+          ProcedureFactory.EMAIL_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("plus+sign@apple.net", "PID-13.4",
+          ProcedureFactory.EMAIL_LETTER_TO_NUMBER, transformer);
 
-    testVariationDifferent("5678 Wooster Ln", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("1234 Howard Drive", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("600 Denter St.", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("5678 Wooster Ln", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("1234 Howard Drive", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("600 Denter St.", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_LETTER_TO_NUMBER, transformer);
 
-    testVariationDifferent("Madison", "PID-11.3", ProcedureFactory.ADDRESS_CITY_LETTER_TO_NUMBER,
-        transformer);
-    testVariationDifferent("New York City", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_LETTER_TO_NUMBER, transformer);
-    testVariationDifferent("Martha's Vineyard", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Madison", "PID-11.3", ProcedureFactory.ADDRESS_CITY_LETTER_TO_NUMBER,
+          transformer);
+      testVariationDifferent("New York City", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_LETTER_TO_NUMBER, transformer);
+      testVariationDifferent("Martha's Vineyard", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_LETTER_TO_NUMBER, transformer);
 
-    // assert only changes required field
-    testWrongHookup("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testWrongHookup("Robert", "PID-5.2", ProcedureFactory.FIRST_NAME_LETTER_TO_NUMBER, transformer);
-    testWrongHookup("Middleditch", "PID-5.3", ProcedureFactory.MIDDLE_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testWrongHookup("Madre", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testWrongHookup("Judy", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_LETTER_TO_NUMBER,
-        transformer);
-    testWrongHookup("5678 Wooster Ln", "PID-11.1", ProcedureFactory.ADDRESS_STREET_LETTER_TO_NUMBER,
-        transformer);
-    testWrongHookup("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_LETTER_TO_NUMBER,
-        transformer);
+      // assert only changes required field
+      testWrongHookup("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testWrongHookup("Robert", "PID-5.2", ProcedureFactory.FIRST_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testWrongHookup("Middleditch", "PID-5.3", ProcedureFactory.MIDDLE_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testWrongHookup("Madre", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testWrongHookup("Judy", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_LETTER_TO_NUMBER,
+          transformer);
+      testWrongHookup("5678 Wooster Ln", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_LETTER_TO_NUMBER, transformer);
+      testWrongHookup("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_LETTER_TO_NUMBER,
+          transformer);
+    }
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,

--- a/src/test/java/org/immregistries/smm/transform/procedure/TextNumberToLetterTypoTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/TextNumberToLetterTypoTest.java
@@ -13,106 +13,109 @@ public class TextNumberToLetterTypoTest extends ProcedureCommonTest {
   public void test() {
     Transformer transformer = new Transformer();
 
-    assertEquals("A", new TextNumberToLetterTypo(null).varyText("A", transformer));
-    assertEquals("a", new TextNumberToLetterTypo(null).varyText("a", transformer));
-    assertEquals("0", new TextNumberToLetterTypo(null).varyText("0", transformer));
-    assertEquals("", new TextNumberToLetterTypo(null).varyText("", transformer));
+    for (int i = 0; i < 100; i++) {
+      assertEquals("A", new TextNumberToLetterTypo(null).varyText("A", transformer));
+      assertEquals("a", new TextNumberToLetterTypo(null).varyText("a", transformer));
+      assertEquals("0", new TextNumberToLetterTypo(null).varyText("0", transformer));
+      assertEquals("", new TextNumberToLetterTypo(null).varyText("", transformer));
 
-    assertEquals("1st Son", new TextNumberToLetterTypo(null).varyText("1st Son", transformer));
+      assertEquals("1st Son", new TextNumberToLetterTypo(null).varyText("1st Son", transformer));
 
-    assertEquals("Bob", new TextNumberToLetterTypo(null).varyText("Bob", transformer));
-    assertEquals("Robert Paulson",
-        new TextNumberToLetterTypo(null).varyText("Robert Paulson", transformer));
-    assertEquals("Grant-Bob", new TextNumberToLetterTypo(null).varyText("Grant-Bob", transformer));
+      assertEquals("Bob", new TextNumberToLetterTypo(null).varyText("Bob", transformer));
+      assertEquals("Robert Paulson",
+          new TextNumberToLetterTypo(null).varyText("Robert Paulson", transformer));
+      assertEquals("Grant-Bob",
+          new TextNumberToLetterTypo(null).varyText("Grant-Bob", transformer));
 
-    testVariationDifferent("CARPENTER5", "PID-5.1", ProcedureFactory.LAST_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testVariationDifferent("Washington 16", "PID-5.1", ProcedureFactory.LAST_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testVariationDifferent("Hyphen-n8d", "PID-5.1", ProcedureFactory.LAST_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testVariationSame("Twolast Names", "PID-5.1", ProcedureFactory.LAST_NAME_NUMBER_TO_LETTER,
-        transformer);
+      testVariationDifferent("CARPENTER5", "PID-5.1", ProcedureFactory.LAST_NAME_NUMBER_TO_LETTER,
+          transformer);
+      testVariationDifferent("Washington 16", "PID-5.1",
+          ProcedureFactory.LAST_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("Hyphen-n8d", "PID-5.1", ProcedureFactory.LAST_NAME_NUMBER_TO_LETTER,
+          transformer);
+      testVariationSame("Twolast Names", "PID-5.1", ProcedureFactory.LAST_NAME_NUMBER_TO_LETTER,
+          transformer);
 
-    testVariationDifferent("Samu3l", "PID-5.2", ProcedureFactory.FIRST_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testVariationDifferent("Emily the 2nd", "PID-5.2", ProcedureFactory.FIRST_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testVariationDifferent("Mary 9ue", "PID-5.2", ProcedureFactory.FIRST_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testVariationSame("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_NUMBER_TO_LETTER,
-        transformer);
+      testVariationDifferent("Samu3l", "PID-5.2", ProcedureFactory.FIRST_NAME_NUMBER_TO_LETTER,
+          transformer);
+      testVariationDifferent("Emily the 2nd", "PID-5.2",
+          ProcedureFactory.FIRST_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("Mary 9ue", "PID-5.2", ProcedureFactory.FIRST_NAME_NUMBER_TO_LETTER,
+          transformer);
+      testVariationSame("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_NUMBER_TO_LETTER,
+          transformer);
 
-    testVariationDifferent("Jenn1fer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testVariationDifferent("Ryan the 7th", "PID-5.3", ProcedureFactory.MIDDLE_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testVariationDifferent("F5rederick Dempsey", "PID-5.3",
-        ProcedureFactory.MIDDLE_NAME_NUMBER_TO_LETTER, transformer);
-    testVariationSame("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_NUMBER_TO_LETTER,
-        transformer);
+      testVariationDifferent("Jenn1fer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_NUMBER_TO_LETTER,
+          transformer);
+      testVariationDifferent("Ryan the 7th", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("F5rederick Dempsey", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationSame("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_NUMBER_TO_LETTER,
+          transformer);
 
-    testVariationDifferent("Grace 3", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_NUMBER_TO_LETTER, transformer);
-    testVariationDifferent("Patrick 4", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_NUMBER_TO_LETTER, transformer);
-    testVariationDifferent("Ziegfried 5", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_NUMBER_TO_LETTER, transformer);
-    testVariationSame("Threepwood", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("Grace 3", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("Patrick 4", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("Ziegfried 5", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationSame("Threepwood", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_NUMBER_TO_LETTER, transformer);
 
-    testVariationDifferent("Sandra 7", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_NUMBER_TO_LETTER, transformer);
-    testVariationDifferent("Emily 8", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_NUMBER_TO_LETTER, transformer);
-    testVariationDifferent("Mary Sue 9", "PID-6.2",
-        ProcedureFactory.MOTHERS_FIRST_NAME_NUMBER_TO_LETTER, transformer);
-    testVariationSame("Ye Sune", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_NUMBER_TO_LETTER,
-        transformer);
+      testVariationDifferent("Sandra 7", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("Emily 8", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("Mary Sue 9", "PID-6.2",
+          ProcedureFactory.MOTHERS_FIRST_NAME_NUMBER_TO_LETTER, transformer);
+      testVariationSame("Ye Sune", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_NUMBER_TO_LETTER,
+          transformer);
 
-    testVariationDifferent("4356180", "PID-13.7", ProcedureFactory.PHONE_NUMBER_TO_LETTER,
-        transformer);
-    testVariationDifferent("1234567", "PID-13.7", ProcedureFactory.PHONE_NUMBER_TO_LETTER,
-        transformer);
-    testVariationDifferent("555-5555", "PID-13.7", ProcedureFactory.PHONE_NUMBER_TO_LETTER,
-        transformer);
-    testVariationDifferent("555-5555 ext. 555", "PID-13.7", ProcedureFactory.PHONE_NUMBER_TO_LETTER,
-        transformer);
+      testVariationDifferent("4356180", "PID-13.7", ProcedureFactory.PHONE_NUMBER_TO_LETTER,
+          transformer);
+      testVariationDifferent("1234567", "PID-13.7", ProcedureFactory.PHONE_NUMBER_TO_LETTER,
+          transformer);
+      testVariationDifferent("555-5555", "PID-13.7", ProcedureFactory.PHONE_NUMBER_TO_LETTER,
+          transformer);
+      testVariationDifferent("555-5555 ext. 555", "PID-13.7",
+          ProcedureFactory.PHONE_NUMBER_TO_LETTER, transformer);
 
-    testVariationDifferent("something64@gmail.com", "PID-13.4",
-        ProcedureFactory.EMAIL_NUMBER_TO_LETTER, transformer);
-    testVariationDifferent("plus1+1sign@apple.net", "PID-13.4",
-        ProcedureFactory.EMAIL_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("something64@gmail.com", "PID-13.4",
+          ProcedureFactory.EMAIL_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("plus1+1sign@apple.net", "PID-13.4",
+          ProcedureFactory.EMAIL_NUMBER_TO_LETTER, transformer);
 
-    testVariationDifferent("5678 Wooster Ln", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_NUMBER_TO_LETTER, transformer);
-    testVariationDifferent("1234 Howard Drive", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_NUMBER_TO_LETTER, transformer);
-    testVariationDifferent("600 Denter St.", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("5678 Wooster Ln", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("1234 Howard Drive", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("600 Denter St.", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_NUMBER_TO_LETTER, transformer);
 
-    testVariationDifferent("Madis0n", "PID-11.3", ProcedureFactory.ADDRESS_CITY_NUMBER_TO_LETTER,
-        transformer);
-    testVariationDifferent("New York C1ty", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_NUMBER_TO_LETTER, transformer);
-    testVariationSame("Martha's Vineyard", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_NUMBER_TO_LETTER, transformer);
+      testVariationDifferent("Madis0n", "PID-11.3", ProcedureFactory.ADDRESS_CITY_NUMBER_TO_LETTER,
+          transformer);
+      testVariationDifferent("New York C1ty", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_NUMBER_TO_LETTER, transformer);
+      testVariationSame("Martha's Vineyard", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_NUMBER_TO_LETTER, transformer);
 
-    // assert only changes required field
-    testWrongHookup("Washington 1", "PID-5.1", ProcedureFactory.LAST_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testWrongHookup("Robert 2", "PID-5.2", ProcedureFactory.FIRST_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testWrongHookup("Middleditch 3", "PID-5.3", ProcedureFactory.MIDDLE_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testWrongHookup("Madre 4", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testWrongHookup("Judy 5", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_NUMBER_TO_LETTER,
-        transformer);
-    testWrongHookup("5678 Wooster Ln", "PID-11.1", ProcedureFactory.ADDRESS_STREET_NUMBER_TO_LETTER,
-        transformer);
-    testWrongHookup("New York City 6", "PID-11.3", ProcedureFactory.ADDRESS_CITY_NUMBER_TO_LETTER,
-        transformer);
+      // assert only changes required field
+      testWrongHookup("Washington 1", "PID-5.1", ProcedureFactory.LAST_NAME_NUMBER_TO_LETTER,
+          transformer);
+      testWrongHookup("Robert 2", "PID-5.2", ProcedureFactory.FIRST_NAME_NUMBER_TO_LETTER,
+          transformer);
+      testWrongHookup("Middleditch 3", "PID-5.3", ProcedureFactory.MIDDLE_NAME_NUMBER_TO_LETTER,
+          transformer);
+      testWrongHookup("Madre 4", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_NUMBER_TO_LETTER,
+          transformer);
+      testWrongHookup("Judy 5", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_NUMBER_TO_LETTER,
+          transformer);
+      testWrongHookup("5678 Wooster Ln", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_NUMBER_TO_LETTER, transformer);
+      testWrongHookup("New York City 6", "PID-11.3", ProcedureFactory.ADDRESS_CITY_NUMBER_TO_LETTER,
+          transformer);
+    }
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,

--- a/src/test/java/org/immregistries/smm/transform/procedure/TextRandomTypoTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/TextRandomTypoTest.java
@@ -10,78 +10,83 @@ public class TextRandomTypoTest extends ProcedureCommonTest {
   public void test() {
     Transformer transformer = new Transformer();
 
-    testVariationDifferent("CARPENTER", "PID-5.1", ProcedureFactory.LAST_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Twolast Names", "PID-5.1", ProcedureFactory.LAST_NAME_RANDOM_TYPO,
-        transformer);
+    for (int i = 0; i < 100; i++) {
+      testVariationDifferent("CARPENTER", "PID-5.1", ProcedureFactory.LAST_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Twolast Names", "PID-5.1", ProcedureFactory.LAST_NAME_RANDOM_TYPO,
+          transformer);
 
-    testVariationDifferent("Samuel", "PID-5.2", ProcedureFactory.FIRST_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Emily", "PID-5.2", ProcedureFactory.FIRST_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Mary Sue", "PID-5.2", ProcedureFactory.FIRST_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_RANDOM_TYPO,
-        transformer);
+      testVariationDifferent("Samuel", "PID-5.2", ProcedureFactory.FIRST_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Emily", "PID-5.2", ProcedureFactory.FIRST_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Mary Sue", "PID-5.2", ProcedureFactory.FIRST_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_RANDOM_TYPO,
+          transformer);
 
-    testVariationDifferent("Jennifer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Ryan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Frederick Dempsey", "PID-5.3", ProcedureFactory.MIDDLE_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_RANDOM_TYPO,
-        transformer);
+      testVariationDifferent("Jennifer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Ryan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Frederick Dempsey", "PID-5.3",
+          ProcedureFactory.MIDDLE_NAME_RANDOM_TYPO, transformer);
+      testVariationDifferent("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_RANDOM_TYPO,
+          transformer);
 
-    testVariationDifferent("Grace", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Patrick", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Ziegfried", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Threepwood", "PID-6.1",
-        ProcedureFactory.MOTHERS_MAIDEN_NAME_RANDOM_TYPO, transformer);
+      testVariationDifferent("Grace", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Patrick", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Ziegfried", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_RANDOM_TYPO, transformer);
+      testVariationDifferent("Threepwood", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_RANDOM_TYPO, transformer);
 
-    testVariationDifferent("Sandra", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Emily", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Mary Sue", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Ye Sune", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_RANDOM_TYPO,
-        transformer);
+      testVariationDifferent("Sandra", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Emily", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Mary Sue", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Ye Sune", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_RANDOM_TYPO,
+          transformer);
 
-    testVariationDifferent("4356180", "PID-13.7", ProcedureFactory.PHONE_RANDOM_TYPO, transformer);
-    testVariationDifferent("1234567", "PID-13.7", ProcedureFactory.PHONE_RANDOM_TYPO, transformer);
-    testVariationDifferent("555-5555", "PID-13.7", ProcedureFactory.PHONE_RANDOM_TYPO, transformer);
+      testVariationDifferent("4356180", "PID-13.7", ProcedureFactory.PHONE_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("1234567", "PID-13.7", ProcedureFactory.PHONE_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("555-5555", "PID-13.7", ProcedureFactory.PHONE_RANDOM_TYPO,
+          transformer);
 
-    testVariationDifferent("something@gmail.com", "PID-13.4", ProcedureFactory.EMAIL_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("plus+sign@apple.net", "PID-13.4", ProcedureFactory.EMAIL_RANDOM_TYPO,
-        transformer);
+      testVariationDifferent("something@gmail.com", "PID-13.4", ProcedureFactory.EMAIL_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("plus+sign@apple.net", "PID-13.4", ProcedureFactory.EMAIL_RANDOM_TYPO,
+          transformer);
 
-    testVariationDifferent("5678 Wooster Ln", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_RANDOM_TYPO, transformer);
-    testVariationDifferent("1234 Howard Drive", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_RANDOM_TYPO, transformer);
-    testVariationDifferent("600 Denter St.", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_RANDOM_TYPO, transformer);
+      testVariationDifferent("5678 Wooster Ln", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_RANDOM_TYPO, transformer);
+      testVariationDifferent("1234 Howard Drive", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_RANDOM_TYPO, transformer);
+      testVariationDifferent("600 Denter St.", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_RANDOM_TYPO, transformer);
 
-    testVariationDifferent("Madison", "PID-11.3", ProcedureFactory.ADDRESS_CITY_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_RANDOM_TYPO,
-        transformer);
-    testVariationDifferent("Martha's Vineyard", "PID-11.3",
-        ProcedureFactory.ADDRESS_CITY_RANDOM_TYPO, transformer);
+      testVariationDifferent("Madison", "PID-11.3", ProcedureFactory.ADDRESS_CITY_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_RANDOM_TYPO,
+          transformer);
+      testVariationDifferent("Martha's Vineyard", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_RANDOM_TYPO, transformer);
+    }
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,
       Transformer transformer) {
-    assertNotEquals(startValue, new TextTypo(null).varyText(startValue, transformer));
+    assertNotEquals(startValue, new TextRandomTypo(null).varyText(startValue, transformer));
     String testStart = transform(DEFAULT_TEST_MESSAGE, location + "=" + startValue);
     testProcedureChangesMessageAndDoesNotContain(testStart, startValue, procedure);
   }

--- a/src/test/java/org/immregistries/smm/transform/procedure/TextTransposeTypoTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/TextTransposeTypoTest.java
@@ -13,96 +13,104 @@ public class TextTransposeTypoTest extends ProcedureCommonTest {
   public void test() {
     Transformer transformer = new Transformer();
 
-    assertEquals("A", new TextTransposeTypo(null).varyText("A", transformer));
-    assertEquals("a", new TextTransposeTypo(null).varyText("a", transformer));
+    for (int i = 0; i < 100; i++) {
+      assertEquals("A", new TextTransposeTypo(null).varyText("A", transformer));
+      assertEquals("a", new TextTransposeTypo(null).varyText("a", transformer));
 
-    assertEquals("Bo", new TextTransposeTypo(null).varyText("Bo", transformer));
-    assertEquals("BO", new TextTransposeTypo(null).varyText("BO", transformer));
-    assertEquals("bo", new TextTransposeTypo(null).varyText("bo", transformer));
+      assertEquals("Bo", new TextTransposeTypo(null).varyText("Bo", transformer));
+      assertEquals("BO", new TextTransposeTypo(null).varyText("BO", transformer));
+      assertEquals("bo", new TextTransposeTypo(null).varyText("bo", transformer));
 
-    assertEquals("Aym", new TextTransposeTypo(null).varyText("Amy", transformer));
-    assertEquals("CLA", new TextTransposeTypo(null).varyText("CAL", transformer));
-    assertEquals("jmi", new TextTransposeTypo(null).varyText("jim", transformer));
+      assertEquals("Aym", new TextTransposeTypo(null).varyText("Amy", transformer));
+      assertEquals("CLA", new TextTransposeTypo(null).varyText("CAL", transformer));
+      assertEquals("jmi", new TextTransposeTypo(null).varyText("jim", transformer));
 
-    assertEquals("Boo", new TextTransposeTypo(null).varyText("Boo", transformer));
-    assertEquals("Lolo", new TextTransposeTypo(null).varyText("Lool", transformer));
+      assertEquals("Boo", new TextTransposeTypo(null).varyText("Boo", transformer));
+      assertEquals("Lolo", new TextTransposeTypo(null).varyText("Lool", transformer));
 
-    testVariationDifferent("CARPENTER", "PID-5.1", ProcedureFactory.LAST_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Twolast Names", "PID-5.1", ProcedureFactory.LAST_NAME_TRANSPOSE,
-        transformer);
+      testVariationDifferent("CARPENTER", "PID-5.1", ProcedureFactory.LAST_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Twolast Names", "PID-5.1", ProcedureFactory.LAST_NAME_TRANSPOSE,
+          transformer);
 
-    testVariationDifferent("Samuel", "PID-5.2", ProcedureFactory.FIRST_NAME_TRANSPOSE, transformer);
-    testVariationDifferent("Emily", "PID-5.2", ProcedureFactory.FIRST_NAME_TRANSPOSE, transformer);
-    testVariationDifferent("Mary Sue", "PID-5.2", ProcedureFactory.FIRST_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_TRANSPOSE,
-        transformer);
+      testVariationDifferent("Samuel", "PID-5.2", ProcedureFactory.FIRST_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Emily", "PID-5.2", ProcedureFactory.FIRST_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Mary Sue", "PID-5.2", ProcedureFactory.FIRST_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_TRANSPOSE,
+          transformer);
 
-    testVariationDifferent("Jennifer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Ryan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TRANSPOSE, transformer);
-    testVariationDifferent("Frederick Dempsey", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TRANSPOSE, transformer);
+      testVariationDifferent("Jennifer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Ryan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Frederick Dempsey", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TRANSPOSE,
+          transformer);
 
-    testVariationDifferent("Grace", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Patrick", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Ziegfried", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Threepwood", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TRANSPOSE,
-        transformer);
+      testVariationDifferent("Grace", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Patrick", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Ziegfried", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Threepwood", "PID-6.1",
+          ProcedureFactory.MOTHERS_MAIDEN_NAME_TRANSPOSE, transformer);
 
-    testVariationDifferent("Sandra", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Emily", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Mary Sue", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Ye Sune", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TRANSPOSE,
-        transformer);
+      testVariationDifferent("Sandra", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Emily", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Mary Sue", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Ye Sune", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TRANSPOSE,
+          transformer);
 
-    testVariationDifferent("4356180", "PID-13.7", ProcedureFactory.PHONE_TRANSPOSE, transformer);
-    testVariationDifferent("1234567", "PID-13.7", ProcedureFactory.PHONE_TRANSPOSE, transformer);
-    testVariationDifferent("555-5555", "PID-13.7", ProcedureFactory.PHONE_TRANSPOSE, transformer);
+      testVariationDifferent("4356180", "PID-13.7", ProcedureFactory.PHONE_TRANSPOSE, transformer);
+      testVariationDifferent("1234567", "PID-13.7", ProcedureFactory.PHONE_TRANSPOSE, transformer);
+      testVariationDifferent("555-5555", "PID-13.7", ProcedureFactory.PHONE_TRANSPOSE, transformer);
 
-    testVariationDifferent("something@gmail.com", "PID-13#2.7", ProcedureFactory.EMAIL_TRANSPOSE,
-        transformer);
-    testVariationDifferent("plus+sign@apple.net", "PID-13#2.7", ProcedureFactory.EMAIL_TRANSPOSE,
-        transformer);
+      testVariationDifferent("something@gmail.com", "PID-13#2.7", ProcedureFactory.EMAIL_TRANSPOSE,
+          transformer);
+      testVariationDifferent("plus+sign@apple.net", "PID-13#2.7", ProcedureFactory.EMAIL_TRANSPOSE,
+          transformer);
 
-    testVariationDifferent("5678 Wooster Ln", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TRANSPOSE,
-        transformer);
-    testVariationDifferent("1234 Howard Drive", "PID-11.1",
-        ProcedureFactory.ADDRESS_STREET_TRANSPOSE, transformer);
-    testVariationDifferent("600 Denter St.", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TRANSPOSE,
-        transformer);
+      testVariationDifferent("5678 Wooster Ln", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_TRANSPOSE, transformer);
+      testVariationDifferent("1234 Howard Drive", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_TRANSPOSE, transformer);
+      testVariationDifferent("600 Denter St.", "PID-11.1",
+          ProcedureFactory.ADDRESS_STREET_TRANSPOSE, transformer);
 
-    testVariationDifferent("Madison", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TRANSPOSE,
-        transformer);
-    testVariationDifferent("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TRANSPOSE,
-        transformer);
-    testVariationDifferent("Martha's Vineyard", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TRANSPOSE,
-        transformer);
+      testVariationDifferent("Madison", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TRANSPOSE,
+          transformer);
+      testVariationDifferent("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TRANSPOSE,
+          transformer);
+      testVariationDifferent("Martha's Vineyard", "PID-11.3",
+          ProcedureFactory.ADDRESS_CITY_TRANSPOSE, transformer);
 
-    // assert only changes required field
-    testWrongHookup("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_TRANSPOSE, transformer);
-    testWrongHookup("Robert", "PID-5.2", ProcedureFactory.FIRST_NAME_TRANSPOSE, transformer);
-    testWrongHookup("Middleditch", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TRANSPOSE, transformer);
-    testWrongHookup("Madre", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TRANSPOSE,
-        transformer);
-    testWrongHookup("Judy", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TRANSPOSE, transformer);
-    testWrongHookup("4356180", "PID-13.7", ProcedureFactory.PHONE_TRANSPOSE, transformer);
-    testWrongHookup("5678 Wooster Ln", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TRANSPOSE,
-        transformer);
-    testWrongHookup("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TRANSPOSE,
-        transformer);
+      // assert only changes required field
+      testWrongHookup("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_TRANSPOSE, transformer);
+      testWrongHookup("Robert", "PID-5.2", ProcedureFactory.FIRST_NAME_TRANSPOSE, transformer);
+      testWrongHookup("Middleditch", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TRANSPOSE,
+          transformer);
+      testWrongHookup("Madre", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TRANSPOSE,
+          transformer);
+      testWrongHookup("Judy", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TRANSPOSE,
+          transformer);
+      testWrongHookup("4356180", "PID-13.7", ProcedureFactory.PHONE_TRANSPOSE, transformer);
+      testWrongHookup("5678 Wooster Ln", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TRANSPOSE,
+          transformer);
+      testWrongHookup("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TRANSPOSE,
+          transformer);
+    }
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,

--- a/src/test/java/org/immregistries/smm/transform/procedure/TextTypoTest.java
+++ b/src/test/java/org/immregistries/smm/transform/procedure/TextTypoTest.java
@@ -14,84 +14,87 @@ public class TextTypoTest extends ProcedureCommonTest {
   public void test() {
     Transformer transformer = new Transformer();
 
-    testVariationDifferent("CARPENTER", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO, transformer);
-    testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO, transformer);
-    testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO, transformer);
-    testVariationDifferent("Twolast Names", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO,
-        transformer);
+    for (int i = 0; i < 100; i++) {
+      testVariationDifferent("CARPENTER", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO, transformer);
+      testVariationDifferent("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO, transformer);
+      testVariationDifferent("Hyphen-nated", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO,
+          transformer);
+      testVariationDifferent("Twolast Names", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO,
+          transformer);
 
-    testVariationDifferent("Samuel", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
-    testVariationDifferent("Emily", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
-    testVariationDifferent("Mary Sue", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
-    testVariationDifferent("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
+      testVariationDifferent("Samuel", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
+      testVariationDifferent("Emily", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
+      testVariationDifferent("Mary Sue", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
+      testVariationDifferent("Ye Sune", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
 
-    testVariationDifferent("Jennifer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO, transformer);
-    testVariationDifferent("Ryan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO, transformer);
-    testVariationDifferent("Frederick Dempsey", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO,
-        transformer);
-    testVariationDifferent("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO, transformer);
+      testVariationDifferent("Jennifer", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO, transformer);
+      testVariationDifferent("Ryan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO, transformer);
+      testVariationDifferent("Frederick Dempsey", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO,
+          transformer);
+      testVariationDifferent("Stan", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO, transformer);
 
-    testVariationDifferent("Grace", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO,
-        transformer);
-    testVariationDifferent("Patrick", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO,
-        transformer);
-    testVariationDifferent("Ziegfried", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO,
-        transformer);
-    testVariationDifferent("Threepwood", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO,
-        transformer);
+      testVariationDifferent("Grace", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO,
+          transformer);
+      testVariationDifferent("Patrick", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO,
+          transformer);
+      testVariationDifferent("Ziegfried", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO,
+          transformer);
+      testVariationDifferent("Threepwood", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO,
+          transformer);
 
-    testVariationDifferent("Sandra", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO,
-        transformer);
-    testVariationDifferent("Emily", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO,
-        transformer);
-    testVariationDifferent("Mary Sue", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO,
-        transformer);
-    testVariationDifferent("Ye Sune", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO,
-        transformer);
+      testVariationDifferent("Sandra", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO,
+          transformer);
+      testVariationDifferent("Emily", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO,
+          transformer);
+      testVariationDifferent("Mary Sue", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO,
+          transformer);
+      testVariationDifferent("Ye Sune", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO,
+          transformer);
 
-    testVariationDifferent("4356180", "PID-13.7", ProcedureFactory.PHONE_TYPO, transformer);
-    testVariationDifferent("1234567", "PID-13.7", ProcedureFactory.PHONE_TYPO, transformer);
-    testVariationDifferent("555-5555", "PID-13.7", ProcedureFactory.PHONE_TYPO, transformer);
+      testVariationDifferent("4356180", "PID-13.7", ProcedureFactory.PHONE_TYPO, transformer);
+      testVariationDifferent("1234567", "PID-13.7", ProcedureFactory.PHONE_TYPO, transformer);
+      testVariationDifferent("555-5555", "PID-13.7", ProcedureFactory.PHONE_TYPO, transformer);
 
-    testVariationDifferent("something@gmail.com", "PID-13.4", ProcedureFactory.EMAIL_TYPO,
-        transformer);
-    testVariationDifferent("plus+sign@apple.net", "PID-13.4", ProcedureFactory.EMAIL_TYPO,
-        transformer);
+      testVariationDifferent("something@gmail.com", "PID-13.4", ProcedureFactory.EMAIL_TYPO,
+          transformer);
+      testVariationDifferent("plus+sign@apple.net", "PID-13.4", ProcedureFactory.EMAIL_TYPO,
+          transformer);
 
-    testVariationDifferent("5678 Wooster Ln", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TYPO,
-        transformer);
-    testVariationDifferent("1234 Howard Drive", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TYPO,
-        transformer);
-    testVariationDifferent("600 Denter St.", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TYPO,
-        transformer);
+      testVariationDifferent("5678 Wooster Ln", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TYPO,
+          transformer);
+      testVariationDifferent("1234 Howard Drive", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TYPO,
+          transformer);
+      testVariationDifferent("600 Denter St.", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TYPO,
+          transformer);
 
-    testVariationDifferent("Madison", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TYPO, transformer);
-    testVariationDifferent("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TYPO,
-        transformer);
-    testVariationDifferent("Martha's Vineyard", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TYPO,
-        transformer);
+      testVariationDifferent("Madison", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TYPO,
+          transformer);
+      testVariationDifferent("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TYPO,
+          transformer);
+      testVariationDifferent("Martha's Vineyard", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TYPO,
+          transformer);
 
-    // assert only changes required field
-    testWrongHookup("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO, transformer);
-    testWrongHookup("Robert", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
-    testWrongHookup("Middleditch", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO, transformer);
-    testWrongHookup("Madre", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO, transformer);
-    testWrongHookup("Judy", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO, transformer);
-    testWrongHookup("4356180", "PID-13.7", ProcedureFactory.PHONE_TYPO, transformer);
-    testWrongHookup("5678 Wooster Ln", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TYPO,
-        transformer);
-    testWrongHookup("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TYPO, transformer);
+      // assert only changes required field
+      testWrongHookup("Washington", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO, transformer);
+      testWrongHookup("Robert", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
+      testWrongHookup("Middleditch", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO, transformer);
+      testWrongHookup("Madre", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO, transformer);
+      testWrongHookup("Judy", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO, transformer);
+      testWrongHookup("4356180", "PID-13.7", ProcedureFactory.PHONE_TYPO, transformer);
+      testWrongHookup("5678 Wooster Ln", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TYPO,
+          transformer);
+      testWrongHookup("New York City", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TYPO, transformer);
 
-    // support empty string doesn't do anything
-    testVariationSame("", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO, transformer);
-    testVariationSame("", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
-    testVariationSame("", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO, transformer);
-    testVariationSame("", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO,
-        transformer);
-    testVariationSame("", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO, transformer);
-    testVariationSame("", "PID-13.7", ProcedureFactory.PHONE_TYPO, transformer);
-    testVariationSame("", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TYPO, transformer);
-    testVariationSame("", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TYPO, transformer);
+      // support empty string doesn't do anything
+      testVariationSame("", "PID-5.1", ProcedureFactory.LAST_NAME_TYPO, transformer);
+      testVariationSame("", "PID-5.2", ProcedureFactory.FIRST_NAME_TYPO, transformer);
+      testVariationSame("", "PID-5.3", ProcedureFactory.MIDDLE_NAME_TYPO, transformer);
+      testVariationSame("", "PID-6.1", ProcedureFactory.MOTHERS_MAIDEN_NAME_TYPO, transformer);
+      testVariationSame("", "PID-6.2", ProcedureFactory.MOTHERS_FIRST_NAME_TYPO, transformer);
+      testVariationSame("", "PID-13.7", ProcedureFactory.PHONE_TYPO, transformer);
+      testVariationSame("", "PID-11.1", ProcedureFactory.ADDRESS_STREET_TYPO, transformer);
+      testVariationSame("", "PID-11.3", ProcedureFactory.ADDRESS_CITY_TYPO, transformer);
+    }
   }
 
   private void testVariationDifferent(String startValue, String location, String procedure,


### PR DESCRIPTION
https://github.com/immregistries-internal/AART/issues/2666

ProcedureCommon.makeEmailValid() takes an email address and tries its best to make it valid:

- eliminate spaces
- local part (left side of @ sign) can't start or end with a period, eliminate them
- local part can't have multiple periods in a row, replace with single period
- local part must be 64 characters or less, truncate at 64 characters
- domain part (right side of @ sign) can't start or end with period or hyphen, eliminate
- domain part can't have multiple periods in a row, replace with single period
- if there's no domain, add @gmail.com

This applies to these email procedures:

* alternative vowels
* alternative beginnings
* alternative endings
* alternative ending vowels
* special characters
* special characters extended
* typo
* transpose typo
* letter to number typo
* number to letter typo
* random typo
* text change
* repeated consonants
* hyphenate variation

I also expanded out related testing to make sure it's applied, especially on the more random ones, there's some loops now to test over and over (a lot of the line changes are churn from being put in a for loop).